### PR TITLE
[BE - #38]  퀴즈 관련 도메인 구축 및 생성 API 구현

### DIFF
--- a/packages/BE/src/app.module.ts
+++ b/packages/BE/src/app.module.ts
@@ -8,10 +8,12 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { MysqlConfigModule } from './config/database/mysql/configuration.module';
 import { TypeOrmModuleOptions } from '@nestjs/typeorm';
 import { UserModule } from './module/user/user.module';
+import { QuizModule } from './module/quiz/quiz.module';
 
 @Module({
   imports: [
     UserModule,
+    QuizModule,
     MysqlConfigModule,
     TypeOrmModule.forRootAsync({
       imports: [ConfigModule],

--- a/packages/BE/src/module/quiz/quiz.module.ts
+++ b/packages/BE/src/module/quiz/quiz.module.ts
@@ -6,13 +6,17 @@ import { Class } from './quizzes/entities/class.entity';
 import { QuizRepository } from './quizzes/repositories/quiz.repository';
 import { ChoiceRepository } from './quizzes/repositories/choice.repository';
 import { ClassRepository } from './quizzes/repositories/class.repository';
+import { QuizService } from './quizzes/quiz.service';
+import { QuizController } from './quizzes/quiz.controller';
 
 
 @Module({
     imports: [
         TypeOrmModule.forFeature([Quiz, Choice, Class])
     ],
+    controllers: [QuizController],
     providers: [
+        QuizService,
         QuizRepository,
         ChoiceRepository,
         ClassRepository

--- a/packages/BE/src/module/quiz/quiz.module.ts
+++ b/packages/BE/src/module/quiz/quiz.module.ts
@@ -1,0 +1,26 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Quiz } from './quizzes/entities/quiz.entity';
+import { Choice } from './quizzes/entities/choice.entity';
+import { Class } from './quizzes/entities/class.entity';
+import { QuizRepository } from './quizzes/repositories/quiz.repository';
+import { ChoiceRepository } from './quizzes/repositories/choice.repository';
+import { ClassRepository } from './quizzes/repositories/class.repository';
+
+
+@Module({
+    imports: [
+        TypeOrmModule.forFeature([Quiz, Choice, Class])
+    ],
+    providers: [
+        QuizRepository,
+        ChoiceRepository,
+        ClassRepository
+    ],
+    exports: [
+        QuizRepository,
+        ChoiceRepository,
+        ClassRepository
+    ]
+})
+export class QuizModule {}

--- a/packages/BE/src/module/quiz/quizzes/dto/create-choice.request.dto.ts
+++ b/packages/BE/src/module/quiz/quizzes/dto/create-choice.request.dto.ts
@@ -1,0 +1,11 @@
+import { IsNotEmpty, IsString, IsNumber } from 'class-validator';
+
+export class CreateChoiceRequestDto {
+    @IsString()
+    @IsNotEmpty()
+    content: string;
+
+    @IsNumber()
+    @IsNotEmpty()
+    is_correct: boolean;
+}

--- a/packages/BE/src/module/quiz/quizzes/dto/create-choice.request.dto.ts
+++ b/packages/BE/src/module/quiz/quizzes/dto/create-choice.request.dto.ts
@@ -1,11 +1,15 @@
-import { IsNotEmpty, IsString, IsNumber } from 'class-validator';
+import { IsNotEmpty, IsString, IsBoolean, IsNumber } from 'class-validator';
 
 export class CreateChoiceRequestDto {
+    @IsNumber()
+    @IsNotEmpty()
+    position: number;
+    
     @IsString()
     @IsNotEmpty()
     content: string;
 
-    @IsNumber()
+    @IsBoolean()
     @IsNotEmpty()
-    is_correct: boolean;
+    isCorrect: boolean;
 }

--- a/packages/BE/src/module/quiz/quizzes/dto/create-class.request.dto.ts
+++ b/packages/BE/src/module/quiz/quizzes/dto/create-class.request.dto.ts
@@ -1,12 +1,6 @@
-import { IsNotEmpty, IsString, IsNumber, IsArray, ValidateNested } from 'class-validator';
-import { Type } from 'class-transformer';
-import { CreateQuizRequestDto } from '../../quizzes/dto/create-quiz.request.dto';
+import { IsNotEmpty, IsString } from 'class-validator';
 
 export class CreateClassRequestDto {
-    @IsNumber()
-    @IsNotEmpty()
-    creator_id: number;
-
     @IsString()
     @IsNotEmpty()
     title: string;
@@ -14,9 +8,4 @@ export class CreateClassRequestDto {
     @IsString()
     @IsNotEmpty()
     description: string;
-
-    @IsArray()
-    @ValidateNested({ each: true })
-    @Type(() => CreateQuizRequestDto)
-    quizzes: CreateQuizRequestDto[];
 }

--- a/packages/BE/src/module/quiz/quizzes/dto/create-class.request.dto.ts
+++ b/packages/BE/src/module/quiz/quizzes/dto/create-class.request.dto.ts
@@ -1,0 +1,15 @@
+import { IsNotEmpty, IsString, IsNumber} from 'class-validator';
+
+export class CreateClassRequestDto {
+    @IsNumber()
+    @IsNotEmpty()
+    creator_id: number;
+
+    @IsString()
+    @IsNotEmpty()
+    title: string;
+
+    @IsString()
+    @IsNotEmpty()
+    description: string;
+}

--- a/packages/BE/src/module/quiz/quizzes/dto/create-class.request.dto.ts
+++ b/packages/BE/src/module/quiz/quizzes/dto/create-class.request.dto.ts
@@ -1,4 +1,6 @@
-import { IsNotEmpty, IsString, IsNumber} from 'class-validator';
+import { IsNotEmpty, IsString, IsNumber, IsArray, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+import { CreateQuizRequestDto } from '../../quizzes/dto/create-quiz.request.dto';
 
 export class CreateClassRequestDto {
     @IsNumber()
@@ -12,4 +14,9 @@ export class CreateClassRequestDto {
     @IsString()
     @IsNotEmpty()
     description: string;
+
+    @IsArray()
+    @ValidateNested({ each: true })
+    @Type(() => CreateQuizRequestDto)
+    quizzes: CreateQuizRequestDto[];
 }

--- a/packages/BE/src/module/quiz/quizzes/dto/create-quiz.request.dto.ts
+++ b/packages/BE/src/module/quiz/quizzes/dto/create-quiz.request.dto.ts
@@ -5,7 +5,7 @@ import { CreateChoiceRequestDto } from "./create-choice.request.dto";
 export class CreateQuizRequestDto {
     @IsNumber()
     @IsNotEmpty()
-    creator_id: number;
+    position: number;
 
     @IsString()
     @IsNotEmpty()
@@ -13,19 +13,19 @@ export class CreateQuizRequestDto {
 
     @IsNumber()
     @IsNotEmpty()
-    time_limit: number;
+    timeLimit: number;
 
     @IsNumber()
     @IsNotEmpty()
     point: number;
 
-    @IsNumber()
+    @IsString()
     @IsNotEmpty()
-    question_type: number;
+    questionType: string;
 
-    @IsNumber()
-    @IsNotEmpty()
-    position: number;
+    // @IsNumber()
+    // @IsNotEmpty()
+    // position: number;
 
     @IsArray()
     @ValidateNested({ each: true })

--- a/packages/BE/src/module/quiz/quizzes/dto/create-quiz.request.dto.ts
+++ b/packages/BE/src/module/quiz/quizzes/dto/create-quiz.request.dto.ts
@@ -1,4 +1,6 @@
-import { IsNotEmpty, IsString, IsNumber } from "class-validator";
+import { IsNotEmpty, IsString, IsNumber, IsArray, ValidateNested } from "class-validator";
+import { Type } from "class-transformer";
+import { CreateChoiceRequestDto } from "./create-choice.request.dto";
 
 export class CreateQuizRequestDto {
     @IsNumber()
@@ -24,4 +26,9 @@ export class CreateQuizRequestDto {
     @IsNumber()
     @IsNotEmpty()
     position: number;
+
+    @IsArray()
+    @ValidateNested({ each: true })
+    @Type(() => CreateChoiceRequestDto)
+    choices: CreateChoiceRequestDto[];
 }

--- a/packages/BE/src/module/quiz/quizzes/dto/create-quiz.request.dto.ts
+++ b/packages/BE/src/module/quiz/quizzes/dto/create-quiz.request.dto.ts
@@ -1,0 +1,27 @@
+import { IsNotEmpty, IsString, IsNumber } from "class-validator";
+
+export class CreateQuizRequestDto {
+    @IsNumber()
+    @IsNotEmpty()
+    creator_id: number;
+
+    @IsString()
+    @IsNotEmpty()
+    content: string;
+
+    @IsNumber()
+    @IsNotEmpty()
+    time_limit: number;
+
+    @IsNumber()
+    @IsNotEmpty()
+    point: number;
+
+    @IsNumber()
+    @IsNotEmpty()
+    question_type: number;
+
+    @IsNumber()
+    @IsNotEmpty()
+    position: number;
+}

--- a/packages/BE/src/module/quiz/quizzes/dto/create-quizlist.request.dto.ts
+++ b/packages/BE/src/module/quiz/quizzes/dto/create-quizlist.request.dto.ts
@@ -3,10 +3,6 @@ import { Type } from 'class-transformer';
 import { CreateQuizRequestDto } from './create-quiz.request.dto';
 
 export class CreateQuizListRequestDto {
-    @IsNumber()
-    @IsNotEmpty()
-    classId: number;
-
     @IsArray()
     @ValidateNested({ each: true })
     @Type(() => CreateQuizRequestDto)

--- a/packages/BE/src/module/quiz/quizzes/dto/create-quizlist.request.dto.ts
+++ b/packages/BE/src/module/quiz/quizzes/dto/create-quizlist.request.dto.ts
@@ -1,0 +1,14 @@
+import { IsNumber, IsNotEmpty, IsArray, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+import { CreateQuizRequestDto } from './create-quiz.request.dto';
+
+export class CreateQuizListRequestDto {
+    @IsNumber()
+    @IsNotEmpty()
+    classId: number;
+
+    @IsArray()
+    @ValidateNested({ each: true })
+    @Type(() => CreateQuizRequestDto)
+    quizzes: CreateQuizRequestDto[];
+}

--- a/packages/BE/src/module/quiz/quizzes/entities/choice.entity.ts
+++ b/packages/BE/src/module/quiz/quizzes/entities/choice.entity.ts
@@ -1,0 +1,13 @@
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity()
+export class Choice {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    content: string;
+
+    @Column()
+    is_correct: boolean;
+}

--- a/packages/BE/src/module/quiz/quizzes/entities/choice.entity.ts
+++ b/packages/BE/src/module/quiz/quizzes/entities/choice.entity.ts
@@ -6,6 +6,12 @@ export class Choice {
     id: number;
 
     @Column()
+    quiz_id: number;
+
+    @Column()
+    position: number;
+
+    @Column()
     content: string;
 
     @Column()

--- a/packages/BE/src/module/quiz/quizzes/entities/class.entity.ts
+++ b/packages/BE/src/module/quiz/quizzes/entities/class.entity.ts
@@ -1,0 +1,19 @@
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity()
+export class ClassEntity {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    creator_id: number;
+
+    @Column()
+    title: string;
+
+    @Column()
+    description: string;
+
+    @Column()
+    created_at: Date;
+}

--- a/packages/BE/src/module/quiz/quizzes/entities/class.entity.ts
+++ b/packages/BE/src/module/quiz/quizzes/entities/class.entity.ts
@@ -1,7 +1,7 @@
 import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
 
 @Entity()
-export class ClassEntity {
+export class Class {
     @PrimaryGeneratedColumn()
     id: number;
 

--- a/packages/BE/src/module/quiz/quizzes/entities/quiz.entity.ts
+++ b/packages/BE/src/module/quiz/quizzes/entities/quiz.entity.ts
@@ -9,6 +9,9 @@ export class Quiz {
     class_id: number;
 
     @Column()
+    position: number
+
+    @Column()
     content: string;
 
     @Column()
@@ -18,8 +21,8 @@ export class Quiz {
     point: number;
 
     @Column()
-    question_type: number;  // 퀴즈 타입에 따른 구분이 가능한 String Enum 혹은 정수로 해도 좋을 것 같음
+    question_type: string;  // 퀴즈 타입에 따른 구분이 가능한 String Enum 혹은 정수로 해도 좋을 것 같음
 
-    @Column()
-    position: number;
+    // @Column()
+    // position: number;
 }

--- a/packages/BE/src/module/quiz/quizzes/entities/quiz.entity.ts
+++ b/packages/BE/src/module/quiz/quizzes/entities/quiz.entity.ts
@@ -1,0 +1,25 @@
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity()
+export class QuizEntity {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    class_id: number;
+
+    @Column()
+    content: string;
+
+    @Column()
+    time_limit: number;
+
+    @Column()
+    point: number;
+
+    @Column()
+    question_type: number;  // 퀴즈 타입에 따른 구분이 가능한 String Enum 혹은 정수로 해도 좋을 것 같음
+
+    @Column()
+    position: number;
+}

--- a/packages/BE/src/module/quiz/quizzes/entities/quiz.entity.ts
+++ b/packages/BE/src/module/quiz/quizzes/entities/quiz.entity.ts
@@ -1,7 +1,7 @@
 import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
 
 @Entity()
-export class QuizEntity {
+export class Quiz {
     @PrimaryGeneratedColumn()
     id: number;
 

--- a/packages/BE/src/module/quiz/quizzes/quiz.controller.ts
+++ b/packages/BE/src/module/quiz/quizzes/quiz.controller.ts
@@ -1,0 +1,7 @@
+import { Controller } from "@nestjs/common";
+import { QuizService } from "./quiz.service";
+
+@Controller('api/quiz')
+export class QuizController {
+    constructor( private readonly quizService : QuizService) {}
+}

--- a/packages/BE/src/module/quiz/quizzes/quiz.controller.ts
+++ b/packages/BE/src/module/quiz/quizzes/quiz.controller.ts
@@ -1,6 +1,8 @@
-import { Body, Controller, Post, UsePipes, ValidationPipe } from "@nestjs/common";
+import { Body, Controller, Delete, Post, UsePipes, ValidationPipe } from "@nestjs/common";
 import { QuizService } from "./quiz.service";
+// index.ts barrel file로 처리해도 좋을 듯.
 import { CreateClassRequestDto } from "./dto/create-class.request.dto";
+import { CreateQuizListRequestDto } from "./dto/create-quizlist.request.dto";
 
 @Controller('api/quiz')
 export class QuizController {
@@ -9,8 +11,19 @@ export class QuizController {
     // class 생성
     @Post('create-class')
     @UsePipes(ValidationPipe)
-    async createQuiz(@Body() createClassRequestDto : CreateClassRequestDto) {
-        // const response = await this.quizService.createQuiz();
-        // return response;
+    async createClass(@Body() dto : CreateClassRequestDto) {
+        return await this.quizService.createClass(dto);
     }
+
+    @Post('create-quiz')
+    @UsePipes(ValidationPipe)
+    async createQuiz(@Body() dto : CreateQuizListRequestDto) {
+        return await this.quizService.createQuiz(dto);
+    }
+
+    // @Delete('delete-class')
+    // @UsePipes(ValidationPipe)
+    // async deleteQuiz(@Body() dto : CreateClassRequestDto) {
+    //     return await this.quizService.deleteClass(dto);
+    // }
 }

--- a/packages/BE/src/module/quiz/quizzes/quiz.controller.ts
+++ b/packages/BE/src/module/quiz/quizzes/quiz.controller.ts
@@ -1,7 +1,19 @@
-import { Controller } from "@nestjs/common";
+import { Body, Controller, Post, UsePipes, ValidationPipe } from "@nestjs/common";
 import { QuizService } from "./quiz.service";
+import { CreateClassRequestDto } from "./dto/create-class.request.dto";
 
 @Controller('api/quiz')
 export class QuizController {
     constructor( private readonly quizService : QuizService) {}
+
+    // class 생성
+    @Post('create-class')
+    @UsePipes(ValidationPipe)
+    async createQuiz(@Body() createClassRequestDto : CreateClassRequestDto) {
+        try {
+            return this.quizService.createQuiz();
+        } catch(err) {
+            console.log(err);
+        }
+    }
 }

--- a/packages/BE/src/module/quiz/quizzes/quiz.controller.ts
+++ b/packages/BE/src/module/quiz/quizzes/quiz.controller.ts
@@ -1,24 +1,25 @@
-import { Body, Controller, Delete, Post, UsePipes, ValidationPipe } from "@nestjs/common";
+import { Body, Controller, Param, Post, UsePipes, ValidationPipe } from "@nestjs/common";
 import { QuizService } from "./quiz.service";
 // index.ts barrel file로 처리해도 좋을 듯.
 import { CreateClassRequestDto } from "./dto/create-class.request.dto";
 import { CreateQuizListRequestDto } from "./dto/create-quizlist.request.dto";
 
-@Controller('api/quiz')
+@Controller('api')
 export class QuizController {
     constructor( private readonly quizService : QuizService) {}
 
     // class 생성
-    @Post('create-class')
+    @Post('classes')
     @UsePipes(ValidationPipe)
     async createClass(@Body() dto : CreateClassRequestDto) {
         return await this.quizService.createClass(dto);
     }
 
-    @Post('create-quiz')
+    @Post('classes/:classId/quizzes')
     @UsePipes(ValidationPipe)
-    async createQuiz(@Body() dto : CreateQuizListRequestDto) {
-        return await this.quizService.createQuiz(dto);
+    async createQuiz(@Param('classId') classId: number,
+    @Body() dto : CreateQuizListRequestDto) {
+        return await this.quizService.createQuiz(classId, dto);
     }
 
     // @Delete('delete-class')

--- a/packages/BE/src/module/quiz/quizzes/quiz.controller.ts
+++ b/packages/BE/src/module/quiz/quizzes/quiz.controller.ts
@@ -10,10 +10,7 @@ export class QuizController {
     @Post('create-class')
     @UsePipes(ValidationPipe)
     async createQuiz(@Body() createClassRequestDto : CreateClassRequestDto) {
-        try {
-            return this.quizService.createQuiz();
-        } catch(err) {
-            console.log(err);
-        }
+        // const response = await this.quizService.createQuiz();
+        // return response;
     }
 }

--- a/packages/BE/src/module/quiz/quizzes/quiz.service.ts
+++ b/packages/BE/src/module/quiz/quizzes/quiz.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class QuizService {
+    constructor() {
+        console.log('QuizService');
+    }
+}

--- a/packages/BE/src/module/quiz/quizzes/quiz.service.ts
+++ b/packages/BE/src/module/quiz/quizzes/quiz.service.ts
@@ -33,7 +33,7 @@ export class QuizService {
     }
 
     // dto가 여러개라서 처리하기 좀 그러네 quiz, choice는 dto가 아니라 인터페이스로 구현하는게 좋지않을까라는 생각...?
-    async createQuiz(quizData: CreateQuizListRequestDto): Promise<ResponseDto> {
+    async createQuiz(classId: number, quizData: CreateQuizListRequestDto): Promise<ResponseDto> {
         // 그럼 이 컨트롤러에서 dto 구분이 힘들다
         // 너무 이 메서드에 책임이 많은게 아닌가 라는 생각도 든다.
         // const queryRunner = this.dataSource.createQueryRunner();
@@ -41,14 +41,14 @@ export class QuizService {
         // await queryRunner.startTransaction();
         try {
             // class_id가 유효한지 확인
-            const is_valid_class = await this.classRepository.findClassById(quizData.classId);
+            const is_valid_class = await this.classRepository.findClassById(classId);
             if (!is_valid_class) {
-                throw new Error(`Class with ID ${quizData.classId} not found`);
+                throw new Error(`Class with ID ${classId} not found`);
             }
 
             await Promise.all(
                 quizData.quizzes.map(async (quiz) => {
-                    const quizEntity = await this.quizRepository.create(quizData.classId, quiz);
+                    const quizEntity = await this.quizRepository.create(classId, quiz);
                     quiz.choices.map(async (choice) => {
                         this.choiceRepository.create(quizEntity.id, choice);
                     });

--- a/packages/BE/src/module/quiz/quizzes/quiz.service.ts
+++ b/packages/BE/src/module/quiz/quizzes/quiz.service.ts
@@ -5,4 +5,8 @@ export class QuizService {
     constructor() {
         console.log('QuizService');
     }
+
+    createQuiz() {
+
+    }
 }

--- a/packages/BE/src/module/quiz/quizzes/quiz.service.ts
+++ b/packages/BE/src/module/quiz/quizzes/quiz.service.ts
@@ -1,41 +1,94 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, HttpException, HttpStatus, Param } from '@nestjs/common';
+import { DataSource } from 'typeorm';
 import { QuizRepository } from './repositories/quiz.repository';
 import { ChoiceRepository } from './repositories/choice.repository';
 import { ClassRepository } from './repositories/class.repository';
+import { CreateClassRequestDto } from './dto/create-class.request.dto';    
+import { CreateQuizListRequestDto } from './dto/create-quizlist.request.dto';
 import { CreateQuizRequestDto } from './dto/create-quiz.request.dto';
+import { CreateChoiceRequestDto } from './dto/create-choice.request.dto';
+import { ResponseDto } from '../../utils/dto/response.dto';
 import { Quiz } from './entities/quiz.entity';
+import { Class } from './entities/class.entity';
+import { Choice } from './entities/choice.entity';
 
 @Injectable()
 export class QuizService {
     constructor(
         private readonly quizRepository: QuizRepository,
         private readonly choiceRepository: ChoiceRepository,
-        private readonly classRepository: ClassRepository
+        private readonly classRepository: ClassRepository,
+        private readonly dataSource: DataSource,
     ) {}
 
-    // async createQuiz(createQuizRequestDto: CreateQuizRequestDto): Promise<Quiz> {}
+    async createClass(createClassRequestDto: CreateClassRequestDto): Promise<void> {
+        try {
+            const classData = await this.classRepository.create({
+                title: createClassRequestDto.title,
+                description: createClassRequestDto.description,
+            });
+        } catch (error) {
+            console.error('error:', error);
+        }
+    }
+
+    // dto가 여러개라서 처리하기 좀 그러네 quiz, choice는 dto가 아니라 인터페이스로 구현하는게 좋지않을까라는 생각...?
+    async createQuiz(quizData: CreateQuizListRequestDto): Promise<ResponseDto> {
+        // 그럼 이 컨트롤러에서 dto 구분이 힘들다
+        // 너무 이 메서드에 책임이 많은게 아닌가 라는 생각도 든다.
+        // const queryRunner = this.dataSource.createQueryRunner();
+        // await queryRunner.connect();
+        // await queryRunner.startTransaction();
+        try {
+            // class_id가 유효한지 확인
+            const is_valid_class = await this.classRepository.findClassById(quizData.classId);
+            if (!is_valid_class) {
+                throw new Error(`Class with ID ${quizData.classId} not found`);
+            }
+
+            await Promise.all(
+                quizData.quizzes.map(async (quiz) => {
+                    const quizEntity = await this.quizRepository.create(quizData.classId, quiz);
+                    quiz.choices.map(async (choice) => {
+                        this.choiceRepository.create(quizEntity.id, choice);
+                    });
+                }
+            ));
+
+            // await queryRunner.commitTransaction();
+
+
+            return {
+                success: true,
+                message: 'Quiz created successfully',
+            };
+        } catch (error) {
+            // await queryRunner.rollbackTransaction();
+            throw new HttpException({
+                status: HttpStatus.FORBIDDEN,
+                error: `${error}`,
+            }, HttpStatus.FORBIDDEN, {
+                cause: error
+            });
+        }        
+        // } finally {
+        //     await queryRunner.release();
+        // }
+    }
 
     async findAll(): Promise<Quiz[]> {
         return this.quizRepository.findAll();
     }
 
-    async findById(id: number): Promise<Quiz> {
-        const quiz = await this.quizRepository.findById(id);
-        if (!quiz) {
-            throw new NotFoundException(`Quiz with ID ${id} not found`);
-        }
-        return quiz;
-    }
-
-    async findByClassId(class_id: number): Promise<Quiz[]> {
-        const classExists = await this.classRepository.findById(class_id);
-        if (!classExists) {
-            throw new NotFoundException(`Class with ID ${class_id} not found`);
-        }
-        return this.quizRepository.findByClassId(class_id);
-    }
-
+    // async findById(id: number): Promise<Quiz> {
+    //     const quiz = await this.quizRepository.findById(id);
+    //     if (!quiz) {
+    //         throw new NotFoundException(`Quiz with ID ${id} not found`);
+    //     }
+    //     return quiz;
+    // }
     // async updateQuiz(id: number, updateQuizDto: UpdateQuizDto): Promise<Quiz> {}
 
     // async deleteQuiz(id: number): Promise<void> {}
+
 }

--- a/packages/BE/src/module/quiz/quizzes/quiz.service.ts
+++ b/packages/BE/src/module/quiz/quizzes/quiz.service.ts
@@ -1,12 +1,41 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { QuizRepository } from './repositories/quiz.repository';
+import { ChoiceRepository } from './repositories/choice.repository';
+import { ClassRepository } from './repositories/class.repository';
+import { CreateQuizRequestDto } from './dto/create-quiz.request.dto';
+import { Quiz } from './entities/quiz.entity';
 
 @Injectable()
 export class QuizService {
-    constructor() {
-        console.log('QuizService');
+    constructor(
+        private readonly quizRepository: QuizRepository,
+        private readonly choiceRepository: ChoiceRepository,
+        private readonly classRepository: ClassRepository
+    ) {}
+
+    // async createQuiz(createQuizRequestDto: CreateQuizRequestDto): Promise<Quiz> {}
+
+    async findAll(): Promise<Quiz[]> {
+        return this.quizRepository.findAll();
     }
 
-    createQuiz() {
-
+    async findById(id: number): Promise<Quiz> {
+        const quiz = await this.quizRepository.findById(id);
+        if (!quiz) {
+            throw new NotFoundException(`Quiz with ID ${id} not found`);
+        }
+        return quiz;
     }
+
+    async findByClassId(class_id: number): Promise<Quiz[]> {
+        const classExists = await this.classRepository.findById(class_id);
+        if (!classExists) {
+            throw new NotFoundException(`Class with ID ${class_id} not found`);
+        }
+        return this.quizRepository.findByClassId(class_id);
+    }
+
+    // async updateQuiz(id: number, updateQuizDto: UpdateQuizDto): Promise<Quiz> {}
+
+    // async deleteQuiz(id: number): Promise<void> {}
 }

--- a/packages/BE/src/module/quiz/quizzes/repositories/choice.repository.ts
+++ b/packages/BE/src/module/quiz/quizzes/repositories/choice.repository.ts
@@ -1,3 +1,24 @@
 import { Injectable } from "@nestjs/common";
-import { DataSource, Repository } from 'typeorm';
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from 'typeorm';
 import { Choice } from '../entities/choice.entity';
+
+@Injectable()
+export class ChoiceRepository {
+    constructor(
+        @InjectRepository(Choice)
+        private readonly repository: Repository<Choice>
+    ) {}
+
+    async create(choice: Partial<Choice>): Promise<Choice> {
+        return this.repository.save(choice);
+    }
+
+    async findById(id: number): Promise<Choice> {
+        return this.repository.findOne({ where: { id } });
+    }
+
+    async findAll(): Promise<Choice[]> {
+        return this.repository.find();
+    }
+}

--- a/packages/BE/src/module/quiz/quizzes/repositories/choice.repository.ts
+++ b/packages/BE/src/module/quiz/quizzes/repositories/choice.repository.ts
@@ -12,12 +12,12 @@ export class ChoiceRepository {
     ) {}
 
     async create(quiz_id: number, choiceData: CreateChoiceRequestDto): Promise<Choice> {
-        const { position, content, isCorrect } = choiceData;
+        const { position, content, isCorrect: is_correct } = choiceData;
         const choiceEntity = this.repository.create({
             quiz_id,
-            position: choiceData.position,
-            content: choiceData.content,
-            is_correct: choiceData.isCorrect,
+            position,
+            content,
+            is_correct,
         });
         return await this.repository.save(choiceEntity);
     }

--- a/packages/BE/src/module/quiz/quizzes/repositories/choice.repository.ts
+++ b/packages/BE/src/module/quiz/quizzes/repositories/choice.repository.ts
@@ -12,6 +12,7 @@ export class ChoiceRepository {
     ) {}
 
     async create(quiz_id: number, choiceData: CreateChoiceRequestDto): Promise<Choice> {
+        const { position, content, isCorrect } = choiceData;
         const choiceEntity = this.repository.create({
             quiz_id,
             position: choiceData.position,

--- a/packages/BE/src/module/quiz/quizzes/repositories/choice.repository.ts
+++ b/packages/BE/src/module/quiz/quizzes/repositories/choice.repository.ts
@@ -1,0 +1,3 @@
+import { Injectable } from "@nestjs/common";
+import { DataSource, Repository } from 'typeorm';
+import { Choice } from '../entities/choice.entity';

--- a/packages/BE/src/module/quiz/quizzes/repositories/choice.repository.ts
+++ b/packages/BE/src/module/quiz/quizzes/repositories/choice.repository.ts
@@ -2,6 +2,7 @@ import { Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Repository } from 'typeorm';
 import { Choice } from '../entities/choice.entity';
+import { CreateChoiceRequestDto } from "../dto/create-choice.request.dto";
 
 @Injectable()
 export class ChoiceRepository {
@@ -10,9 +11,16 @@ export class ChoiceRepository {
         private readonly repository: Repository<Choice>
     ) {}
 
-    async create(choice: Partial<Choice>): Promise<Choice> {
-        return this.repository.save(choice);
+    async create(quiz_id: number, choiceData: CreateChoiceRequestDto): Promise<Choice> {
+        const choiceEntity = this.repository.create({
+            quiz_id,
+            position: choiceData.position,
+            content: choiceData.content,
+            is_correct: choiceData.isCorrect,
+        });
+        return await this.repository.save(choiceEntity);
     }
+
 
     async findById(id: number): Promise<Choice> {
         return this.repository.findOne({ where: { id } });

--- a/packages/BE/src/module/quiz/quizzes/repositories/class.repository.ts
+++ b/packages/BE/src/module/quiz/quizzes/repositories/class.repository.ts
@@ -14,7 +14,15 @@ export class ClassRepository {
         return this.repository.save(classData);
     }
 
+    // async delete(classData: Partial<Class>): Promise<void> {
+    //     return this.repository.delete(classData);
+    // }
+
     async findById(id: number): Promise<Class> {
+        return this.repository.findOne({ where: { id } });
+    }
+
+    async findClassById(id: number): Promise<Class> {
         return this.repository.findOne({ where: { id } });
     }
 

--- a/packages/BE/src/module/quiz/quizzes/repositories/class.repository.ts
+++ b/packages/BE/src/module/quiz/quizzes/repositories/class.repository.ts
@@ -1,0 +1,10 @@
+import { Injectable } from '@nestjs/common';
+import { DataSource, Repository } from 'typeorm';
+import { Class } from '../entities/class.entity';
+
+@Injectable()
+export class ClassRepository extends Repository<Class> {
+    constructor(private readonly dataSource: DataSource) {
+        super(Class, dataSource.createEntityManager());
+    }
+}

--- a/packages/BE/src/module/quiz/quizzes/repositories/class.repository.ts
+++ b/packages/BE/src/module/quiz/quizzes/repositories/class.repository.ts
@@ -1,10 +1,24 @@
 import { Injectable } from '@nestjs/common';
-import { DataSource, Repository } from 'typeorm';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 import { Class } from '../entities/class.entity';
 
 @Injectable()
-export class ClassRepository extends Repository<Class> {
-    constructor(private readonly dataSource: DataSource) {
-        super(Class, dataSource.createEntityManager());
+export class ClassRepository {
+    constructor(
+        @InjectRepository(Class)
+        private readonly repository: Repository<Class>
+    ) {}
+
+    async create(classData: Partial<Class>): Promise<Class> {
+        return this.repository.save(classData);
+    }
+
+    async findById(id: number): Promise<Class> {
+        return this.repository.findOne({ where: { id } });
+    }
+
+    async findAll(): Promise<Class[]> {
+        return this.repository.find();
     }
 }

--- a/packages/BE/src/module/quiz/quizzes/repositories/quiz.repository.ts
+++ b/packages/BE/src/module/quiz/quizzes/repositories/quiz.repository.ts
@@ -12,13 +12,14 @@ export class QuizRepository {
     ) {}
 
     async create(class_id: number, quiz: CreateQuizRequestDto): Promise<Quiz> {
+        const { position, content, timeLimit: time_limit, point, questionType: question_type } = quiz;
         const quizEntity = this.repository.create({
             class_id,
-            position: quiz.position,
-            content: quiz.content,
-            time_limit: quiz.timeLimit,
-            point: quiz.point,
-            question_type: quiz.questionType,
+            position,
+            content,
+            time_limit,
+            point,
+            question_type,
         });
         return await this.repository.save(quizEntity); // 실제로 데이터베이스에 저장
     }

--- a/packages/BE/src/module/quiz/quizzes/repositories/quiz.repository.ts
+++ b/packages/BE/src/module/quiz/quizzes/repositories/quiz.repository.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Quiz } from '../entities/quiz.entity';
+import { CreateQuizRequestDto } from '../dto/create-quiz.request.dto';
 
 @Injectable()
 export class QuizRepository {
@@ -10,8 +11,16 @@ export class QuizRepository {
         private readonly repository: Repository<Quiz>
     ) {}
 
-    async create(quiz: Partial<Quiz>): Promise<Quiz> {
-        return this.repository.save(quiz);
+    async create(class_id: number, quiz: CreateQuizRequestDto): Promise<Quiz> {
+        const quizEntity = this.repository.create({
+            class_id,
+            position: quiz.position,
+            content: quiz.content,
+            time_limit: quiz.timeLimit,
+            point: quiz.point,
+            question_type: quiz.questionType,
+        });
+        return await this.repository.save(quizEntity); // 실제로 데이터베이스에 저장
     }
 
     async findById(id: number): Promise<Quiz> {

--- a/packages/BE/src/module/quiz/quizzes/repositories/quiz.repository.ts
+++ b/packages/BE/src/module/quiz/quizzes/repositories/quiz.repository.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@nestjs/common';
+import { DataSource, Repository } from 'typeorm';
+import { Quiz } from '../entities/quiz.entity';
+
+@Injectable()
+export class QuizRepository extends Repository<Quiz> {
+    constructor(private readonly dataSource: DataSource) {
+        super(Quiz, dataSource.createEntityManager());
+    }
+
+    async findByClassId(class_id: number): Promise<Quiz[]> {
+        return await this.find({ where: { class_id } });
+    }
+}

--- a/packages/BE/src/module/quiz/quizzes/repositories/quiz.repository.ts
+++ b/packages/BE/src/module/quiz/quizzes/repositories/quiz.repository.ts
@@ -1,14 +1,28 @@
 import { Injectable } from '@nestjs/common';
-import { DataSource, Repository } from 'typeorm';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 import { Quiz } from '../entities/quiz.entity';
 
 @Injectable()
-export class QuizRepository extends Repository<Quiz> {
-    constructor(private readonly dataSource: DataSource) {
-        super(Quiz, dataSource.createEntityManager());
+export class QuizRepository {
+    constructor(
+        @InjectRepository(Quiz)
+        private readonly repository: Repository<Quiz>
+    ) {}
+
+    async create(quiz: Partial<Quiz>): Promise<Quiz> {
+        return this.repository.save(quiz);
+    }
+
+    async findById(id: number): Promise<Quiz> {
+        return this.repository.findOne({ where: { id } });
+    }
+
+    async findAll(): Promise<Quiz[]> {
+        return this.repository.find();
     }
 
     async findByClassId(class_id: number): Promise<Quiz[]> {
-        return await this.find({ where: { class_id } });
+        return this.repository.find({ where: { class_id } });
     }
 }

--- a/packages/BE/src/module/utils/dto/response.dto.ts
+++ b/packages/BE/src/module/utils/dto/response.dto.ts
@@ -1,0 +1,9 @@
+import { IsString, IsBoolean } from 'class-validator';
+
+export class ResponseDto {
+    @IsBoolean()
+    success: boolean;
+
+    @IsString()
+    message: string;
+}   


### PR DESCRIPTION
## #️⃣연관된 이슈

#38 생성된 퀴즈를 저장

## 📝작업 내용
class 생성 API 구현
quiz 생성 API 구현

API '/api/classes/:classId/quizzes'
```
{
  "quizzes": [
    {
      "position": 0,
      "content": "다음 중 2의 제곱은?",
      "timeLimit": 30,
      "point": 1000,
      "questionType": "MULTIPLE_CHOICE",
      "choices": [
        {
          "position": 0,
          "content": "2",
          "isCorrect": false
        },
        {
          "position": 1,
          "content": "4",
          "isCorrect": true
        },
        {
          "position": 2,
          "content": "6",
          "isCorrect": false
        },
        {
          "position": 3,
          "content": "8",
          "isCorrect": false
        }
      ]
    },
    {
      "position": 1,
      "content": "1 + 1 = 2는 참인가요?",
      "timeLimit": 20,
      "point": 500,
      "questionType": "TRUE_FALSE",
      "choices": [
        {
          "position": 0,
          "content": "참",
          "isCorrect": true
        },
        {
          "position": 1,
          "content": "거짓",
          "isCorrect": false
        }
      ]
    }
  ]
}
```

<img width="695" alt="image" src="https://github.com/user-attachments/assets/107c9643-2f5a-4908-a09f-e0dee3ae9769">




### 스크린샷

## 💬리뷰 요구사항
아직 예외 처리가 미흡한 코드입니다. 아직 어떻게 처리할지 고민 중에 있어서 채원 님과 추가 학습 이후에 구현을 해보고 싶습니다.  
현재 코드가 많이 지저분합니다. 신속히 quiz 관련 API를 추가 구현해놓겠습니다.

### 리뷰 적용 사항
- 1 
```typescript
    constructor( private readonly quizService : QuizService) {}

    // class 생성
    @Post('create-class')
```
restful한 API로 수정 -> '/api/classes/:classId/quizzes''

- 2
Entity 저장할 경우 객체 구조 분해 할당으로 재구성

## 참고 자료
