### PR TITLE
[BE - #49] Class 삭제에 따른 Quiz, Choice 삭제

### DIFF
--- a/packages/BE/src/module/quiz/quizzes/dto/create-quiz.request.dto.ts
+++ b/packages/BE/src/module/quiz/quizzes/dto/create-quiz.request.dto.ts
@@ -1,15 +1,16 @@
-import { IsNotEmpty, IsString, IsNumber, IsArray, ValidateNested } from "class-validator";
+import { IsNotEmpty, IsString, IsNumber, IsArray, ValidateNested, IsEnum } from "class-validator";
 import { Type } from "class-transformer";
 import { CreateChoiceRequestDto } from "./create-choice.request.dto";
+import { QuizType } from '../utils/quiz-type.enum';
 
 export class CreateQuizRequestDto {
-    @IsNumber()
-    @IsNotEmpty()
-    position: number;
-
     @IsString()
     @IsNotEmpty()
     content: string;
+
+    @IsEnum(QuizType)
+    @IsNotEmpty()
+    quizType: QuizType;
 
     @IsNumber()
     @IsNotEmpty()
@@ -19,13 +20,9 @@ export class CreateQuizRequestDto {
     @IsNotEmpty()
     point: number;
 
-    @IsString()
+    @IsNumber()
     @IsNotEmpty()
-    questionType: string;
-
-    // @IsNumber()
-    // @IsNotEmpty()
-    // position: number;
+    position: number;
 
     @IsArray()
     @ValidateNested({ each: true })

--- a/packages/BE/src/module/quiz/quizzes/entities/choice.entity.ts
+++ b/packages/BE/src/module/quiz/quizzes/entities/choice.entity.ts
@@ -9,11 +9,14 @@ export class Choice {
     quiz_id: number;
 
     @Column()
-    position: number;
-
-    @Column()
     content: string;
 
     @Column()
     is_correct: boolean;
+
+    @Column()
+    position: number;
+
+    @Column()
+    created_at: Date;
 }

--- a/packages/BE/src/module/quiz/quizzes/entities/class.entity.ts
+++ b/packages/BE/src/module/quiz/quizzes/entities/class.entity.ts
@@ -5,8 +5,8 @@ export class Class {
     @PrimaryGeneratedColumn()
     id: number;
 
-    @Column()
-    creator_id: number;
+    // @Column()
+    // uesr_id: number;
 
     @Column()
     title: string;

--- a/packages/BE/src/module/quiz/quizzes/entities/quiz.entity.ts
+++ b/packages/BE/src/module/quiz/quizzes/entities/quiz.entity.ts
@@ -1,4 +1,5 @@
 import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { QuizType } from '../utils/quiz-type.enum';
 
 @Entity()
 export class Quiz {
@@ -9,10 +10,14 @@ export class Quiz {
     class_id: number;
 
     @Column()
-    position: number
-
-    @Column()
     content: string;
+
+    @Column({
+        type: 'enum',
+        enum: QuizType,
+        default: QuizType.TF,
+    })
+    quiz_type: QuizType;
 
     @Column()
     time_limit: number;
@@ -21,8 +26,8 @@ export class Quiz {
     point: number;
 
     @Column()
-    question_type: string;  // 퀴즈 타입에 따른 구분이 가능한 String Enum 혹은 정수로 해도 좋을 것 같음
+    position: number
 
-    // @Column()
-    // position: number;
+    @Column()
+    created_at: Date;
 }

--- a/packages/BE/src/module/quiz/quizzes/quiz.controller.ts
+++ b/packages/BE/src/module/quiz/quizzes/quiz.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Param, Post, UsePipes, ValidationPipe } from "@nestjs/common";
+import { Body, Controller, Delete, Param, Post, UsePipes, ValidationPipe } from "@nestjs/common";
 import { QuizService } from "./quiz.service";
 // index.ts barrel file로 처리해도 좋을 듯.
 import { CreateClassRequestDto } from "./dto/create-class.request.dto";
@@ -13,6 +13,12 @@ export class QuizController {
     @UsePipes(ValidationPipe)
     async createClass(@Body() dto : CreateClassRequestDto) {
         return await this.quizService.createClass(dto);
+    }
+
+    @Delete('classes/:classId')
+    @UsePipes(ValidationPipe)
+    async deleteClass(@Param('classId') classId: number) {
+        return await this.quizService.deleteClass(classId);
     }
 
     @Post('classes/:classId/quizzes')

--- a/packages/BE/src/module/quiz/quizzes/quiz.service.ts
+++ b/packages/BE/src/module/quiz/quizzes/quiz.service.ts
@@ -23,13 +23,33 @@ export class QuizService {
 
     async createClass(createClassRequestDto: CreateClassRequestDto): Promise<void> {
         try {
-            const classData = await this.classRepository.create({
-                title: createClassRequestDto.title,
-                description: createClassRequestDto.description,
-            });
+            await this.classRepository.create(createClassRequestDto);
         } catch (error) {
             console.error('error:', error);
         }
+    }
+
+    // id에 해당하는 클래스와 퀴즈, 선택지를 삭제한다.
+    async deleteClass(id: number): Promise<ResponseDto> {
+        const classEntity = await this.classRepository.findClassById(id);
+        if (!classEntity) {
+            throw new HttpException(`Class with ID ${id} not found`, HttpStatus.NOT_FOUND);
+        }
+
+        await this.classRepository.deleteById(id);
+
+        const quizzes = await this.quizRepository.findByClassId(id);
+        await Promise.all(
+            quizzes.map(async (quiz) => {
+                await this.choiceRepository.deleteByQuizId(quiz.id);
+            })
+        );
+        await this.quizRepository.deleteByClassId(id);
+
+        return {
+            success: true,
+            message: 'Class deleted successfully',
+        };
     }
 
     // dto가 여러개라서 처리하기 좀 그러네 quiz, choice는 dto가 아니라 인터페이스로 구현하는게 좋지않을까라는 생각...?

--- a/packages/BE/src/module/quiz/quizzes/quiz.service.ts
+++ b/packages/BE/src/module/quiz/quizzes/quiz.service.ts
@@ -29,29 +29,6 @@ export class QuizService {
         }
     }
 
-    // id에 해당하는 클래스와 퀴즈, 선택지를 삭제한다.
-    async deleteClass(id: number): Promise<ResponseDto> {
-        const classEntity = await this.classRepository.findClassById(id);
-        if (!classEntity) {
-            throw new HttpException(`Class with ID ${id} not found`, HttpStatus.NOT_FOUND);
-        }
-
-        await this.classRepository.deleteById(id);
-
-        const quizzes = await this.quizRepository.findByClassId(id);
-        await Promise.all(
-            quizzes.map(async (quiz) => {
-                await this.choiceRepository.deleteByQuizId(quiz.id);
-            })
-        );
-        await this.quizRepository.deleteByClassId(id);
-
-        return {
-            success: true,
-            message: 'Class deleted successfully',
-        };
-    }
-
     // dto가 여러개라서 처리하기 좀 그러네 quiz, choice는 dto가 아니라 인터페이스로 구현하는게 좋지않을까라는 생각...?
     async createQuiz(classId: number, quizData: CreateQuizListRequestDto): Promise<ResponseDto> {
         // 그럼 이 컨트롤러에서 dto 구분이 힘들다
@@ -76,7 +53,6 @@ export class QuizService {
             ));
 
             // await queryRunner.commitTransaction();
-
 
             return {
                 success: true,
@@ -110,5 +86,29 @@ export class QuizService {
     // async updateQuiz(id: number, updateQuizDto: UpdateQuizDto): Promise<Quiz> {}
 
     // async deleteQuiz(id: number): Promise<void> {}
+
+    // id에 해당하는 클래스와 퀴즈, 선택지를 삭제한다.
+    async deleteClass(id: number): Promise<ResponseDto> {
+        const classEntity = await this.classRepository.findClassById(id);
+        if (!classEntity) {
+            throw new HttpException(`Class with ID ${id} not found`, HttpStatus.NOT_FOUND);
+        }
+
+        const quizzes = await this.quizRepository.findByClassId(id);
+        await Promise.all(
+            quizzes.map(async (quiz) => {
+                await this.choiceRepository.deleteByQuizId(quiz.id);
+            })
+        );
+
+        await this.quizRepository.deleteByClassId(id);
+        
+        await this.classRepository.deleteById(id);
+
+        return {
+            success: true,
+            message: 'Class deleted successfully',
+        };
+    }
 
 }

--- a/packages/BE/src/module/quiz/quizzes/repositories/choice.repository.ts
+++ b/packages/BE/src/module/quiz/quizzes/repositories/choice.repository.ts
@@ -15,9 +15,10 @@ export class ChoiceRepository {
         const { position, content, isCorrect: is_correct } = choiceData;
         const choiceEntity = this.repository.create({
             quiz_id,
-            position,
             content,
             is_correct,
+            position,
+            created_at: new Date(),
         });
         return await this.repository.save(choiceEntity);
     }
@@ -30,4 +31,8 @@ export class ChoiceRepository {
     async findAll(): Promise<Choice[]> {
         return this.repository.find();
     }
+
+    async deleteByQuizId(quiz_id: number): Promise<void> {
+        await this.repository.delete({ quiz_id });
+    }   
 }

--- a/packages/BE/src/module/quiz/quizzes/repositories/choice.repository.ts
+++ b/packages/BE/src/module/quiz/quizzes/repositories/choice.repository.ts
@@ -12,7 +12,7 @@ export class ChoiceRepository {
     ) {}
 
     async create(quiz_id: number, choiceData: CreateChoiceRequestDto): Promise<Choice> {
-        const { position, content, isCorrect: is_correct } = choiceData;
+        const { content, isCorrect: is_correct, position } = choiceData;
         const choiceEntity = this.repository.create({
             quiz_id,
             content,
@@ -22,7 +22,6 @@ export class ChoiceRepository {
         });
         return await this.repository.save(choiceEntity);
     }
-
 
     async findById(id: number): Promise<Choice> {
         return this.repository.findOne({ where: { id } });

--- a/packages/BE/src/module/quiz/quizzes/repositories/class.repository.ts
+++ b/packages/BE/src/module/quiz/quizzes/repositories/class.repository.ts
@@ -19,10 +19,6 @@ export class ClassRepository {
         return this.repository.save(classEntity);
     }
 
-    // async delete(classData: Partial<Class>): Promise<void> {
-    //     return this.repository.delete(classData);
-    // }
-
     async findById(id: number): Promise<Class> {
         return this.repository.findOne({ where: { id } });
     }

--- a/packages/BE/src/module/quiz/quizzes/repositories/class.repository.ts
+++ b/packages/BE/src/module/quiz/quizzes/repositories/class.repository.ts
@@ -11,7 +11,12 @@ export class ClassRepository {
     ) {}
 
     async create(classData: Partial<Class>): Promise<Class> {
-        return this.repository.save(classData);
+        const {title, description} = classData;
+        const classEntity = this.repository.create({
+            title,
+            description,
+        });
+        return this.repository.save(classEntity);
     }
 
     // async delete(classData: Partial<Class>): Promise<void> {
@@ -28,5 +33,9 @@ export class ClassRepository {
 
     async findAll(): Promise<Class[]> {
         return this.repository.find();
+    }
+
+    async deleteById(id: number): Promise<void> {
+        await this.repository.delete(id);
     }
 }

--- a/packages/BE/src/module/quiz/quizzes/repositories/quiz.repository.ts
+++ b/packages/BE/src/module/quiz/quizzes/repositories/quiz.repository.ts
@@ -12,14 +12,15 @@ export class QuizRepository {
     ) {}
 
     async create(class_id: number, quiz: CreateQuizRequestDto): Promise<Quiz> {
-        const { position, content, timeLimit: time_limit, point, questionType: question_type } = quiz;
+        const { position, content, timeLimit: time_limit, point, quizType: quiz_type } = quiz;
         const quizEntity = this.repository.create({
             class_id,
-            position,
             content,
+            quiz_type,
             time_limit,
+            position,
             point,
-            question_type,
+            created_at: new Date(),
         });
         return await this.repository.save(quizEntity); // 실제로 데이터베이스에 저장
     }
@@ -34,5 +35,9 @@ export class QuizRepository {
 
     async findByClassId(class_id: number): Promise<Quiz[]> {
         return this.repository.find({ where: { class_id } });
+    }
+
+    async deleteByClassId(class_id: number): Promise<void> {
+        await this.repository.delete({ class_id });
     }
 }

--- a/packages/BE/src/module/quiz/quizzes/repositories/quiz.repository.ts
+++ b/packages/BE/src/module/quiz/quizzes/repositories/quiz.repository.ts
@@ -12,7 +12,7 @@ export class QuizRepository {
     ) {}
 
     async create(class_id: number, quiz: CreateQuizRequestDto): Promise<Quiz> {
-        const { position, content, timeLimit: time_limit, point, quizType: quiz_type } = quiz;
+        const { content, quizType: quiz_type, timeLimit: time_limit, position, point } = quiz;
         const quizEntity = this.repository.create({
             class_id,
             content,
@@ -22,7 +22,7 @@ export class QuizRepository {
             point,
             created_at: new Date(),
         });
-        return await this.repository.save(quizEntity); // 실제로 데이터베이스에 저장
+        return await this.repository.save(quizEntity);
     }
 
     async findById(id: number): Promise<Quiz> {

--- a/packages/BE/src/module/quiz/quizzes/utils/quiz-type.enum.ts
+++ b/packages/BE/src/module/quiz/quizzes/utils/quiz-type.enum.ts
@@ -1,0 +1,4 @@
+export enum QuizType {
+    TF = 'TF',
+    MC = 'MC'
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#49  Class 삭제 API

## 📝작업 내용
API: DELTE '/api/classes/:classId'
![image](https://github.com/user-attachments/assets/299ca0ec-3144-48f2-befb-d03073f978e2)
클래스를 삭제하게되면 참조하고 있는 퀴즈와 선택지를 모두 삭제하게하는 로직을 구성했습니다.

### 스크린샷

## 💬리뷰 요구사항
다만 트랜잭션 구성을 하지 못해서, 퀴즈 삭제 이후 오류가 날 경우.  choice는 정상적으로 저장이 안될 수도 있습니다.
따라서 트랜잭션 코드의 올바른 사용방법을 익힌 뒤 refactoring할 예정입니다.

## 참고 자료
