### PR TITLE
[BE - #89] - show quiz 이벤트 처리 구현

### DIFF
--- a/packages/server/src/module/game/game.gateway.ts
+++ b/packages/server/src/module/game/game.gateway.ts
@@ -34,15 +34,6 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
     console.log(`Client disconnected: ${client.id}`);
   }
 
-  @SubscribeMessage('Quiz')
-  handleQuiz(client: Socket, payload: any) {
-    // classID, 퀴즈의 정보를 가져온다.
-    const quiz = this.redisService.get(payload.classId);
-  }
-
-  @SubscribeMessage('submit')
-  handleSubmit() {}
-
   @SubscribeMessage('master entry')
   async handleMasterEntry(client: Socket, payload: any) {
     // 방장이 게임을 나가도 재접속이 가능하며, 게임은 지속된다.
@@ -82,8 +73,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
     gameInfo.participantList.push(nickname);
     this.redisService.set(`gameId=${pinCode}`, JSON.stringify(gameInfo));
 
-    client.emit('nickname', gameInfo.participantList);
-    client.to(pinCode).emit('nickname', gameInfo.participantList);
+    this.server.to(pinCode).emit('nickname', gameInfo.participantList);
   }
 
   @SubscribeMessage('nickname')
@@ -92,8 +82,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
     const gameInfo = JSON.parse(await this.redisService.get(`gameId=${pinCode}`));
 
-    client.emit('nickname', gameInfo.participantList);
-    client.to(pinCode).emit('nickname', gameInfo.participantList);
+    this.server.to(pinCode).emit('nickname', gameInfo.participantList);
   }
 
   @SubscribeMessage('show quiz')
@@ -112,7 +101,25 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
     // {id, content, choice[]}
     const currentQuizData = quizData[currentOrder];
 
-    client.emit('show quiz', currentQuizData);
-    client.to(pinCode).emit('show quiz', currentQuizData);
+    this.server.to(pinCode).emit('show quiz', currentQuizData);
+
+    gameInfo.currentOrder += 1;
+    await this.redisService.set(`gameId=${pinCode}`, JSON.stringify(gameInfo));
+
+    setTimeout(() => {
+      this.startTimer(pinCode, currentQuizData.timeLimit);
+    }, 2000);
+
+    // redis currentOrder + 1
   }
+
+  startTimer(pinCode: string, timeLimit: number) {
+    // 제한시간이 끝나면.
+    setTimeout(() => {
+      this.server.to(pinCode).emit('timeout', {});
+    }, timeLimit * 1000);
+  }
+
+  //퀴즈를 보내고 나서 타이머 재기 시작
+  // 타이머가 끝나면 이벤트 발생 - 타이머 종료 알림
 }

--- a/packages/server/src/module/game/game.gateway.ts
+++ b/packages/server/src/module/game/game.gateway.ts
@@ -84,7 +84,15 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
     client.emit('nickname', gameInfo.participantList);
     client.to(pinCode).emit('nickname', gameInfo.participantList);
+  }
 
-    return;
+  @SubscribeMessage('nickname')
+  async handleNickname(client: Socket, payload: any) {
+    const { pinCode } = payload;
+
+    const gameInfo = JSON.parse(await this.redisService.get(`gameId=${pinCode}`));
+
+    client.emit('nickname', gameInfo.participantList);
+    client.to(pinCode).emit('nickname', gameInfo.participantList);
   }
 }

--- a/packages/server/src/module/game/game.gateway.ts
+++ b/packages/server/src/module/game/game.gateway.ts
@@ -95,4 +95,24 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
     client.emit('nickname', gameInfo.participantList);
     client.to(pinCode).emit('nickname', gameInfo.participantList);
   }
+
+  @SubscribeMessage('show quiz')
+  async handleShowQuiz(client: Socket, payload: any) {
+    // const isMaster = await this.
+
+    const { pinCode } = payload;
+    // 게임 현재 상태 가져오기
+    const gameInfo = JSON.parse(await this.redisService.get(`gameId=${pinCode}`));
+
+    const { classId, currentOrder, participantList } = gameInfo;
+    // 캐싱된 퀴즈를 가져온다. 퀴즈를 생성할 경우, 만들어졌을거라 예상
+    // 만일 레디스에 퀴즈가 저장되어있지않다면, 퀴즈를 다시 캐싱해오는 로직이 필요할지도.
+    const quizData = JSON.parse(await this.redisService.get(`classId=${classId}`));
+
+    // {id, content, choice[]}
+    const currentQuizData = quizData[currentOrder];
+
+    client.emit('show quiz', currentQuizData);
+    client.to(pinCode).emit('show quiz', currentQuizData);
+  }
 }

--- a/packages/server/src/module/game/games/game.service.ts
+++ b/packages/server/src/module/game/games/game.service.ts
@@ -3,6 +3,8 @@ import { ChoiceRepository } from '../../quiz/quizzes/repositories/choice.reposit
 import { ClassRepository } from '../../quiz/quizzes/repositories/class.repository';
 import { QuizRepository } from '../../quiz/quizzes/repositories/quiz.repository';
 import { RedisService } from '../../../config/database/redis/redis.service';
+import { Quiz } from 'src/module/quiz/quizzes/entities/quiz.entity';
+import { identity } from 'rxjs';
 
 @Injectable()
 export class GameService {
@@ -14,9 +16,34 @@ export class GameService {
   ) {}
 
   async cachingQuizData(classId: number) {
-    const classWithRelations = await this.classRepository.findClassWithRelations(classId);
+    const classWithRelations = await this.findClassWithRelations(classId);
+    const transformedData = this.transformQuizData(classWithRelations);
 
-    return classWithRelations;
+    return transformedData;
+  }
+
+  async findClassWithRelations(id: number) {
+    const classEntity = await this.classRepository.getOnlyQuiz(id);
+
+    return classEntity?.quizzes || [];
+  }
+
+  transformQuizData(quizlists: Quiz[]) {
+    const result = [];
+
+    quizlists.forEach((quiz) => {
+      const choiceList = [];
+      quiz.choices.forEach((choice) => {
+        const { id, quizId, content, isCorrect, position } = choice;
+        const oneChoice = { id, quizId, content, isCorrect, position }; // 인터페이스로 refactor
+        choiceList.push(oneChoice);
+      });
+
+      const { id, content, quizType, timeLimit, point, position } = quiz;
+      const oneQuiz = { id, content, quizType, timeLimit, point, position, choices: choiceList }; // 인터페이스로 refactor
+      result.push(oneQuiz);
+    });
+    return result;
   }
 
   async checkPinCode(pinCode: string) {

--- a/packages/server/src/module/quiz/quizzes/repositories/class.repository.ts
+++ b/packages/server/src/module/quiz/quizzes/repositories/class.repository.ts
@@ -30,6 +30,18 @@ export class ClassRepository {
     return this.repository.findOne({ where: { id } });
   }
 
+  async getOnlyQuiz(id: number) {
+    return this.repository.findOne({
+      where: { id },
+      select: ['quizzes'],
+      relations: {
+        quizzes: {
+          choices: true,
+        },
+      },
+    });
+  }
+
   async findAll(): Promise<Class[]> {
     return this.repository.find();
   }


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- ex) #이슈번호, #이슈번호 -->
#89 show quiz 이벤트 처리 구현
## 📝작업 내용
show quiz
- 퀴즈 데이터들을 필요한 값만 레디스에 저장하도록 transformQuizData 메소드 구현
- 게임 현재 상태를 가져오기
- 현재 상태를 바탕으로 퀴즈 데이터 가져오기
- 가져온 퀴즈 데이터를 같은 room에 있는 client에게 전달

+ 타이머 관련 로직 추가가 필요합니다.

nickname 
- pinCode를 통해 들어온 client들 정보를 레디스에서 가져오기
- 가져온 nickname을 연결된 room의 모든 client에 전달


<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

### 스크린샷

## 💬리뷰 요구사항

리팩토링 할 부분들이 많이 있는 것 같습니다. 해당 부분 잘 기억해두고 기능 개발 후 변경하면 좋을 것 같습니다 !

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->

<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
## 참고 자료
