### PR TITLE
[BE - #90] - timeLimit 변수 인식 못하는 문제 해결

### DIFF
--- a/packages/server/src/module/game/game.gateway.ts
+++ b/packages/server/src/module/game/game.gateway.ts
@@ -24,6 +24,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
     private readonly redisService: RedisService,
     private readonly gameService: GameService,
   ) {}
+
   // 클라이언트가 연결했을 때 처리하는 메서드
   async handleConnection(client: Socket) {
     console.log(`Client connected: ${client.id}`);
@@ -31,6 +32,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
   // 클라이언트가 연결을 끊었을 때 처리하는 메서드
   async handleDisconnect(client: Socket) {
+    //대기 중에 사람이 나갈 경우 갱신해주는 부분 추가 필요
     console.log(`Client disconnected: ${client.id}`);
   }
 
@@ -100,27 +102,26 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
     // 만일 레디스에 퀴즈가 저장되어있지않다면, 퀴즈를 다시 캐싱해오는 로직이 필요할지도.
     const quizData = JSON.parse(await this.redisService.get(`classId=${classId}`));
 
-    // {id, content, choice[]}
     const currentQuizData = quizData[currentOrder];
 
-    // this.server.to(pinCode).emit('show quiz', currentQuizData);
     client.emit('show quiz', currentQuizData);
     client.to(pinCode).emit('show quiz', currentQuizData);
 
-    gameInfo.currentOrder += 1;
+    //gameInfo.currentOrder += 1;
     await this.redisService.set(`gameId=${pinCode}`, JSON.stringify(gameInfo));
 
-    setTimeout(() => {
-      this.startTimer(pinCode, currentQuizData.timeLimit);
-    }, 2000);
-
-    // redis currentOrder + 1
+    // 로딩 2초 지나면, 시간잰다고 알림
+    // setTimeout(() => {
+    //   client.emit('time check', { is_timestart: true });
+    //   this.startTimer(client, pinCode, currentQuizData['timeLimit']);
+    // }, 2000);
   }
 
-  startTimer(pinCode: string, timeLimit: number) {
+  startTimer(client: Socket, pinCode: string, timeLimit: number) {
     // 제한시간이 끝나면.
     setTimeout(() => {
-      this.server.to(pinCode).emit('timeout', {});
+      client.emit('timeout', { is_timeout: true });
+      client.to(pinCode).emit('timeout', { is_timeout: true });
     }, timeLimit * 1000);
   }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- ex) #이슈번호, #이슈번호 -->
#90 퀴즈 데이터 속 timeLimit 변수 인식 못하는 문제 해결
## 📝작업 내용
currentQuizData.timeLimit 로 접근했던 값을 currentQuizData['timeLimit']로 수정해주었습니다. 위와 같이 수정하니 기존에 undefined로 읽혔던 값이 제대로 들어오는 것을 확인할 수 있었습니다.

테스트를 진행하면서 계속 gameInfo.currentOrder += 1 처리를 해주었는데, 현재로써는 퀴즈의 내용이 2개 뿐이라 2보다 현재 순서 값이 커지면 아무 값도 읽어올 수 없었습니다. 해당 부분을 간과하여 이번 오류를 고치는 데 오래 걸렸던 것 같습니다. 
퀴즈 순서를 제어하는 데 관련된 메소드를 추가하던지 등 다음 퀴즈가 남아있지 않다면 하는 처리들을 추가하면 좋을 것 같습니다. 

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

### 스크린샷

## 💬리뷰 요구사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->

<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
## 참고 자료
