### PR TITLE
[BE] - sid의 master, participant 타입 구별 API 구현

### DIFF
--- a/packages/server/src/module/game/game.gateway.ts
+++ b/packages/server/src/module/game/game.gateway.ts
@@ -128,6 +128,21 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
     }, timeLimit * 1000);
   }
 
+  @SubscribeMessage('start quiz')
+  async handleStartQuiz(client: Socket, payload: any) {
+    const { sid, pinCode } = payload;
+
+    const { pinCode: storedPinCode } = JSON.parse(
+      await this.redisService.get(`master_sid=${pinCode}`),
+    );
+
+    if (storedPinCode !== pinCode) {
+      console.log('Invalid pinCode');
+    }
+
+    this.server.to(pinCode).emit('start quiz', { isStarted: true });
+  }
+
   //퀴즈를 보내고 나서 타이머 재기 시작
   // 타이머가 끝나면 이벤트 발생 - 타이머 종료 알림
 }

--- a/packages/server/src/module/game/games/game.controller.ts
+++ b/packages/server/src/module/game/games/game.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, Post, UsePipes, ValidationPipe } from '@nestjs/common';
+import { Controller, Get, Param, UsePipes, ValidationPipe } from '@nestjs/common';
 import { GameService } from './game.service';
 
 @Controller('api')
@@ -9,5 +9,11 @@ export class GameController {
   @UsePipes(ValidationPipe)
   async checkPinCode(@Param('pinCode') pinCode: string) {
     return await this.gameService.checkPinCode(pinCode);
+  }
+
+  @Get('games/:pinCode/sid/:sid')
+  @UsePipes(ValidationPipe)
+  async checkSidType(@Param('sid') sid: string, @Param('pinCode') pinCode: string) {
+    return await this.gameService.checkSidType(sid);
   }
 }

--- a/packages/server/src/module/game/games/game.service.ts
+++ b/packages/server/src/module/game/games/game.service.ts
@@ -58,4 +58,18 @@ export class GameService {
       console.error('error: ', error);
     }
   }
+
+  async checkSidType(sid: string) {
+    try {
+      const keyIds = ['master', 'participant'];
+
+      for (const keyId of keyIds) {
+        if (await this.redisService.get(`${keyId}_sid=${sid}`)) {
+          return { type: keyId };
+        }
+      }
+    } catch (error) {
+      console.error('error: ', error);
+    }
+  }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- ex) #이슈번호, #이슈번호 -->
#95 SID type 구별 API 구현

## 📝작업 내용
- [x]  /api/games/:pinCode/sid/:sid로 get 요청
- [x] parameter 값으로 들어온 sid가 master인지 participant 인지 구별
    - [x] redis에서 확인
    - [x] master일 경우 { type : master }
    - [x] participant일 경우 { type: participant} 
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

### 스크린샷
participant에 해당하는 sid를 보냈을 때 
<img width="225" alt="스크린샷 2024-11-20 오후 5 51 22" src="https://github.com/user-attachments/assets/63e04a35-450b-480e-983c-7c7714a617f7">

master에 해당하는 sid를 보냈을 때 
<img width="201" alt="스크린샷 2024-11-20 오후 5 53 13" src="https://github.com/user-attachments/assets/7403217d-65d9-4400-93b9-3b7793cdf3a5">


## 💬리뷰 요구사항

master_sid=sid값, participant_sid=sid값의 형태로 레디스 키가 설정되어 있기 때문에 key를 구분지을 수 있는 master과 participant를 배열에 넣어 반복문으로 redis에 접근하도록 구현하였습니다. 둘 중 값을 redis에서 값을 제대로 가져오는 경우에 해당하는 type을 return 하도록 했습니다. 

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->

<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
## 참고 자료
