### PR TITLE
[FE] - useGetUserType Query 구현

### DIFF
--- a/packages/client/src/pages/quiz-wait/index.tsx
+++ b/packages/client/src/pages/quiz-wait/index.tsx
@@ -7,6 +7,7 @@ import { getQuizSocket } from '@/shared/utils/socket';
 import { getCookie } from '@/shared/utils/cookie';
 import { toastController } from '@/features/toast/model/toastController';
 import LoadingSpinner from '@/shared/assets/icons/loading-alt-loop.svg?react';
+import { useGetUserType } from '@/shared/hooks/useGetUserType';
 
 const GUEST_DISPLAY_SIZE = { width: 940, height: 568 };
 const SPACING = 10;
@@ -25,7 +26,8 @@ export default function QuizWait() {
   const socket = getQuizSocket();
   const navigate = useNavigate();
   const toast = toastController();
-  const [userType, setUserType] = useState<string>('');
+
+  const { data: userType } = useGetUserType({ pinCode: pinCode!, sid: getCookie('sid')! });
 
   useEffect(() => {
     socket.on('nickname', (response) => {

--- a/packages/client/src/shared/hooks/useGetUserType.ts
+++ b/packages/client/src/shared/hooks/useGetUserType.ts
@@ -1,0 +1,21 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiClient } from '../api';
+
+interface UserTypePayload {
+  pinCode: string;
+  sid: string;
+}
+
+type UserTypeResponse = 'master' | 'participant';
+
+const getUserType = async ({ pinCode, sid }: UserTypePayload): Promise<UserTypeResponse> => {
+  return await apiClient.get(`/games/${pinCode}/sid/${sid}`);
+};
+
+export const useGetUserType = ({ pinCode, sid }: UserTypePayload) => {
+  const { data } = useQuery({
+    queryKey: ['userType', pinCode, sid],
+    queryFn: () => getUserType({ pinCode, sid }),
+  });
+  return { data };
+};


### PR DESCRIPTION
## 📝작업 내용
- 유저 타입을 return 받는 query 훅 구현
- useGetUserType Query wait-page에서 사용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

### 스크린샷

## 💬리뷰 요구사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->

<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
## 참고 자료
