### PR TITLE
[BE - #112] - 이모지 이벤트 추가 및 총 제출 수 이벤트 추가

### DIFF
--- a/packages/server/src/module/game/game.gateway.ts
+++ b/packages/server/src/module/game/game.gateway.ts
@@ -138,6 +138,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
       totalTime: 0,
       choiceStatus,
       submitHistory: [],
+      emojiStatus: { easy: 0, hard: 0 }, ///////////안터페이스 추가
     };
     await this.redisService.set(
       `gameId=${pinCode}:quizId=${currentOrder}`,
@@ -212,6 +213,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
     const quizData = JSON.parse(await this.redisService.get(`classId=${classId}`));
     const currentQuizData = quizData[submittedQuizOrder];
 
+    const participantLength = participantList.length;
     // 현재 퀴즈의 초이스 데이터 가져옴
     const currentChoicesData = currentQuizData['choices'];
 
@@ -261,6 +263,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
     const participantRate = (totalSubmit / participantNum) * 100;
     const participantStatistics = { totalSubmit, solveRate, averageTime, participantRate };
 
+    ///participant length 넘기기
     const masterStatistics = {
       totalSubmit,
       solveRate,
@@ -268,9 +271,25 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
       participantRate,
       choiceStatus,
       submitHistory,
+      participantLength,
     };
     console.log(participantStatistics);
+    client.to(pinCode).emit('total submit count', { totalSubmit });
     this.server.to(pinCode).emit('participant statistics', participantStatistics);
     this.server.to(pinCode).emit('master statistics', masterStatistics);
+  }
+
+  @SubscribeMessage('emoji')
+  async handleEmoji(client: Socket, payload: any) {
+    const { pinCode, currentOrder, emoji } = payload;
+    const gameStatus = JSON.parse(
+      await this.redisService.get(`gameId=${pinCode}:quizId=${currentOrder}`),
+    );
+    gameStatus.emojiStatus[emoji] += 1;
+    await this.redisService.set(
+      `gameId=${pinCode}:quizId=${currentOrder}`,
+      JSON.stringify(gameStatus),
+    );
+    this.server.to(pinCode).emit('emoji', gameStatus.emojiStatus);
   }
 }

--- a/packages/server/src/module/game/game.gateway.ts
+++ b/packages/server/src/module/game/game.gateway.ts
@@ -138,7 +138,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
       totalTime: 0,
       choiceStatus,
       submitHistory: [],
-      emojiStatus: { easy: 0, hard: 0 }, ///////////안터페이스 추가
+      emojiStatus: { easy: 0, hard: 0 },
     };
     await this.redisService.set(
       `gameId=${pinCode}:quizId=${currentOrder}`,
@@ -230,9 +230,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
     const totalSubmit = gameStatus.totalSubmit;
 
     //totalCorrect
-    console.log(selectedAnswer);
     const isFlag = selectedAnswer.every((answer) => {
-      console.log('여기에요', answer);
       return currentChoicesData[answer]['isCorrect'];
     });
     if (isFlag) {
@@ -273,7 +271,6 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
       submitHistory,
       participantLength,
     };
-    console.log(participantStatistics);
     client.to(pinCode).emit('total submit count', { totalSubmit });
     this.server.to(pinCode).emit('participant statistics', participantStatistics);
     this.server.to(pinCode).emit('master statistics', masterStatistics);

--- a/packages/shared/interfaces/request/emoji.request.interface.ts
+++ b/packages/shared/interfaces/request/emoji.request.interface.ts
@@ -1,0 +1,4 @@
+export interface EmojiRequest {
+  pinCode: number;
+  currentOrder: number;
+}

--- a/packages/shared/interfaces/request/index.ts
+++ b/packages/shared/interfaces/request/index.ts
@@ -3,3 +3,4 @@ export * from './nickname.request.interface';
 export * from './participant-entry.request.interface';
 export * from './show-quiz.request.interface';
 export * from './start-quiz.request.interface';
+export * from './emoji.request.interface';

--- a/packages/shared/interfaces/response/emoji.response.interface.ts
+++ b/packages/shared/interfaces/response/emoji.response.interface.ts
@@ -1,0 +1,5 @@
+import { EmojiType } from '../../types/emoji.types';
+
+export interface EmojiResponse {
+  emojiStatus: EmojiType;
+}

--- a/packages/shared/interfaces/response/master-statistics.response.interface.ts
+++ b/packages/shared/interfaces/response/master-statistics.response.interface.ts
@@ -5,4 +5,5 @@ export interface MasterStatisticsResponse {
   participantRate: number;
   choiceStatus: { [key: number]: number };
   submitHistory: [string, number][];
+  participantLength: number;
 }

--- a/packages/shared/types/emoji.types.ts
+++ b/packages/shared/types/emoji.types.ts
@@ -1,0 +1,6 @@
+export const EMOJI_TYPES = {
+  EASY: 'easy',
+  HARD: 'hard',
+} as const;
+
+export type EmojiType = (typeof EMOJI_TYPES)[keyof typeof EMOJI_TYPES];


### PR DESCRIPTION
## #️⃣연관된 이슈
#112 이모지 이벤트 추가 및 총 제출 수 이벤트 추가

<!-- ex) #이슈번호, #이슈번호 -->

## 📝작업 내용
- 이모지 이벤트를 처리하는 부분을 추가했습니다. 
    - 퀴즈 문제 별로 이모지의 상태를 변경하고 redis에 반영
    - 이모지를 누를 때마다 해당하는 이모지의 상태를 올리고 클라이언트 측으로 전송
- 총 제출 인원을 보여주는 부분을 추가했습니다. 
    - submit answer 이벤트를 받을때마다 총 제출 인원을 클라이언트 측으로 전송합니다. 
    - 문제 풀이 화면에서 제출 인원을 보여주는 용도로 사용됩니다.
- 추가된 이벤트에 대한 request, responser 인터페이스를 추가했습니다. 
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

### 스크린샷

## 💬리뷰 요구사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->

<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
## 참고 자료
