### PR TITLE
[BE-#125 #126] 퀴즈 관련 도메인 반환 값 추가 GET API 구현

### DIFF
--- a/packages/server/src/module/quiz/quizzes/dto/choice.response.dto.ts
+++ b/packages/server/src/module/quiz/quizzes/dto/choice.response.dto.ts
@@ -1,0 +1,18 @@
+import { Choice } from '../entities/choice.entity';
+import { ChoiceResponse } from '@shared/interfaces/response/choice.response.interface';
+
+export class ChoiceResponseDto implements ChoiceResponse {
+  id: number;
+  content: string;
+  isCorrect: boolean;
+  position: number;
+
+  static fromEntity(entity: Choice): ChoiceResponseDto {
+    const dto = new ChoiceResponseDto();
+    dto.id = entity.id;
+    dto.content = entity.content;
+    dto.isCorrect = entity.isCorrect;
+    dto.position = entity.position;
+    return dto;
+  }
+}

--- a/packages/server/src/module/quiz/quizzes/dto/create-class.response.dto.ts
+++ b/packages/server/src/module/quiz/quizzes/dto/create-class.response.dto.ts
@@ -1,0 +1,13 @@
+import { Class } from '../entities/class.entity';
+
+export class CreateClassResponseDto {
+  id: number;
+  title: string;
+
+  static fromEntity(entity: Class): CreateClassResponseDto {
+    const dto = new CreateClassResponseDto();
+    dto.id = entity.id;
+    dto.title = entity.title;
+    return dto;
+  }
+}

--- a/packages/server/src/module/quiz/quizzes/dto/quiz.response.dto.ts
+++ b/packages/server/src/module/quiz/quizzes/dto/quiz.response.dto.ts
@@ -1,0 +1,25 @@
+import { QuizResponse } from '@shared/interfaces/response/quiz.response.interface';
+import { ChoiceResponseDto } from './choice.response.dto';
+import { Quiz } from '../entities/quiz.entity';
+
+export class QuizResponseDto implements QuizResponse {
+  id: number;
+  content: string;
+  quizType: string;
+  timeLimit: number;
+  point: number;
+  position: number;
+  choices: ChoiceResponseDto[];
+
+  static fromEntity(entity: Quiz): QuizResponseDto {
+    const dto = new QuizResponseDto();
+    dto.id = entity.id;
+    dto.content = entity.content; // Assuming `content` maps to `question` in `Quiz` entity
+    dto.quizType = entity.quizType;
+    dto.timeLimit = entity.timeLimit;
+    dto.point = entity.point;
+    dto.position = entity.position;
+    dto.choices = entity.choices.map((choice) => ChoiceResponseDto.fromEntity(choice));
+    return dto;
+  }
+}

--- a/packages/server/src/module/quiz/quizzes/quiz.controller.ts
+++ b/packages/server/src/module/quiz/quizzes/quiz.controller.ts
@@ -24,7 +24,11 @@ export class QuizController {
     return await this.quizService.getClasses();
   }
 
-  // class 생성
+  @Get('classes/:classId/quizzes')
+  async getQuizzes(@Param('classId') classId: number) {
+    return await this.quizService.getQuizzesByClassId(classId);
+  }
+
   @Post('classes')
   @UsePipes(ValidationPipe)
   async createClass(@Body() dto: CreateClassRequestDto) {

--- a/packages/server/src/module/quiz/quizzes/quiz.service.ts
+++ b/packages/server/src/module/quiz/quizzes/quiz.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, HttpException, HttpStatus, Param } from '@nestjs/common';
+import { Injectable, HttpException, HttpStatus, Param, NotFoundException } from '@nestjs/common';
 import { DataSource } from 'typeorm';
 import { QuizRepository } from './repositories/quiz.repository';
 import { ChoiceRepository } from './repositories/choice.repository';
@@ -8,9 +8,11 @@ import { CreateQuizListRequestDto } from './dto/create-quizlist.request.dto';
 import { ResponseDto } from '../../utils/dto/response.dto';
 import { Quiz } from './entities/quiz.entity';
 import { ClassResponseDto } from './dto/class.response.dto';
+import { QuizResponseDto } from './dto/quiz.response.dto';
 import { UpdateClassRequestDto } from './dto/update-class.request.dto';
 import { UpdateQuizRequestDto } from './dto/update-quiz.request.dto';
 import { UpdateQuizListRequestDto } from './dto/update-quizlist.request.dto';
+import { CreateClassResponseDto } from './dto/create-class.response.dto';
 
 @Injectable()
 export class QuizService {
@@ -26,11 +28,23 @@ export class QuizService {
     return classes.map(ClassResponseDto.fromEntity);
   }
 
-  async createClass(createClassRequestDto: CreateClassRequestDto): Promise<void> {
+  async getQuizzesByClassId(classId: number): Promise<any> {
+    const quizzes = await this.quizRepository.findByClassId(classId);
+
+    if (!quizzes || quizzes.length === 0) {
+      throw new NotFoundException(`No quizzes found for classId ${classId}`);
+    }
+
+    return quizzes.map((quiz) => QuizResponseDto.fromEntity(quiz));
+  }
+
+  async createClass(createClassRequestDto: CreateClassRequestDto): Promise<CreateClassResponseDto> {
     try {
-      await this.classRepository.create(createClassRequestDto);
+      const classEntity = await this.classRepository.create(createClassRequestDto);
+      return CreateClassResponseDto.fromEntity(classEntity);
     } catch (error) {
       console.error('error:', error);
+      throw error;
     }
   }
 

--- a/packages/server/src/module/quiz/quizzes/repositories/quiz.repository.ts
+++ b/packages/server/src/module/quiz/quizzes/repositories/quiz.repository.ts
@@ -37,7 +37,10 @@ export class QuizRepository {
   }
 
   async findByClassId(classId: number): Promise<Quiz[]> {
-    return this.repository.find({ where: { classId } });
+    return this.repository.find({
+      where: { class: { id: classId } },
+      relations: ['choices'],
+    });
   }
 
   async deleteByClassId(classId: number): Promise<void> {

--- a/packages/shared/interfaces/response/choice.response.interface.ts
+++ b/packages/shared/interfaces/response/choice.response.interface.ts
@@ -1,0 +1,6 @@
+export interface ChoiceResponse {
+  id: number;
+  content: string;
+  isCorrect: boolean;
+  position: number;
+}

--- a/packages/shared/interfaces/response/quiz.response.interface.ts
+++ b/packages/shared/interfaces/response/quiz.response.interface.ts
@@ -1,0 +1,11 @@
+import { ChoiceResponse } from './choice.response.interface';
+
+export interface QuizResponse {
+  id: number;
+  content: string;
+  quizType: string;
+  timeLimit: number;
+  point: number;
+  position: number;
+  choices: ChoiceResponse[];
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
#125 #126 

## 📝작업 내용
- GET API '/api/classes'의 반환값 생성된 class id 반환
- GET API '/api/classes/:classId/quizzes' 구현
- 관련된 response DTO, interface 구현

### 스크린샷
<img width="1258" alt="image" src="https://github.com/user-attachments/assets/15ceb1a7-3301-412f-a0c9-be617682026d">
<img width="1260" alt="image" src="https://github.com/user-attachments/assets/00486a24-8e74-4a41-ae81-87e038a3b3bc">


## 💬리뷰 요구사항

## 참고 자료
