### PR TITLE
[BE] - end quiz 이벤트 구현

### DIFF
--- a/packages/server/src/module/game/game.gateway.ts
+++ b/packages/server/src/module/game/game.gateway.ts
@@ -341,4 +341,17 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
     const response = { rankerDatas, myRank, myScore, myNickname };
     return response;
   }
+
+  @SubscribeMessage('end quiz')
+  async handleEndQuiz(client: Socket, payload: any) {
+    const { sid, pinCode } = payload;
+
+    const { pinCode: storedPinCode } = JSON.parse(await this.redisService.get(`master_sid=${sid}`));
+
+    if (storedPinCode !== pinCode) {
+      console.log('Invalid pinCode');
+    }
+
+    client.to(pinCode).emit('end quiz', { isEnded: true });
+  }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- ex) #이슈번호, #이슈번호 -->

## 📝작업 내용
- 마스터가 end quiz 이벤트를 발생시키면 서버에서 master가 보낸 이벤트인지 여부를 판단하고, 같은pinCode를 가진 클라이언트들에게 end quiz 알림을 전송합니다. 
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

### 스크린샷

## 💬리뷰 요구사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->

<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
## 참고 자료
