### PR TITLE
[FE] - 클래스, 퀴즈 생성 페이지 에러 해결

### DIFF
--- a/packages/client/src/pages/quiz-create/index.tsx
+++ b/packages/client/src/pages/quiz-create/index.tsx
@@ -45,6 +45,16 @@ export default function QuizCreatePage() {
     setCurrentQuizIndex((prev) => prev + 1);
   };
 
+  const removeQuiz = (index: number) => {
+    if (quizzes.length === 1) return;
+    setCurrentQuizIndex((prev) => prev - 1);
+    setQuizzes((prev) => {
+      const newQuizzes = [...prev];
+      newQuizzes.splice(index, 1);
+      return newQuizzes;
+    });
+  };
+
   const handlePreQuiz = () => {
     if (currentQuizIndex === 0) return;
     setCurrentQuizIndex((prev) => prev - 1);
@@ -92,21 +102,26 @@ export default function QuizCreatePage() {
           });
         }}
       />
-      <div className="self-start mt-10">
-        <CustomButton
-          Icon={PlusIcon}
-          type="outline"
-          size="md"
-          color="primary"
-          label="문제 추가하기"
-          onClick={() => {
-            addNewQuiz();
-            console.log(quizzes);
-            console.log(currentQuizIndex);
-          }}
-        />
-      </div>
-      <div className="self-end mr-6">
+      <div className="flex justify-between mt-10 mr-6">
+        <div className="flex gap-6">
+          <CustomButton
+            Icon={PlusIcon}
+            type="outline"
+            size="md"
+            color="primary"
+            label="문제 추가하기"
+            onClick={addNewQuiz}
+          />
+          <button
+            className="flex items-center min-w-fit h-[44px] px-4 py-2.5 bg-white border-2 border-red-500 text-red-500 rounded-base font-medium leading-none text-md
+            disabled:bg-gray-200 disabled:border-gray-300 disabled:text-gray-400 disabled:cursor-not-allowed"
+            onClick={() => removeQuiz(currentQuizIndex)}
+            disabled={quizzes.length === 1 || currentQuizIndex === 0}
+          >
+            <PlusIcon className="w-5 h-5 mr-1 transform rotate-45" />
+            문제 삭제하기
+          </button>
+        </div>
         <CustomButton label="퀴즈 발행하기" onClick={handleCreateQuiz} />
       </div>
     </div>

--- a/packages/client/src/pages/quiz-create/ui/QuizCreateSection.tsx
+++ b/packages/client/src/pages/quiz-create/ui/QuizCreateSection.tsx
@@ -30,7 +30,7 @@ export default function QuizCreateSection({
 
   const updateChoice = (index: number, updates: Partial<(typeof quizData.choices)[0]>) => {
     const updatedChoices = quizData.choices.map((choice, i) =>
-      i === index ? { ...choice, ...updates } : choice,
+      i === index ? { ...choice, ...updates, position: index } : choice,
     );
     onQuizUpdate({
       ...quizData,

--- a/packages/client/src/pages/quiz-list/index.tsx
+++ b/packages/client/src/pages/quiz-list/index.tsx
@@ -1,45 +1,18 @@
-import DownArrowIcon from '@/shared/assets/icons/down-arrow.svg?react';
 import { CustomButton } from '@/shared/ui/buttons';
 import Modal from '@/shared/ui/modal';
 import { useEffect, useState } from 'react';
 import QuizTitleModal from './ui/QuizTitleModal';
-import { useNavigate } from 'react-router-dom';
-import { getQuizSocket } from '@/shared/utils/socket';
-import { setCookie } from '@/shared/utils/cookie';
-import { waitForSocketEvent } from '@/shared/utils/waitForSocketEvent';
 import { useGetClasses } from '@/shared/hooks/classes';
 import { QuizData } from '@/pages/quiz-create';
 import { getQuiz } from '@/shared/api/quizzes';
+import ClassItem from './ui/ClassItem';
 
 type QuizList = QuizData[];
 
 export default function QuizList() {
   const { data: classList } = useGetClasses();
-  const [selectedClassIndex, setSelectedClassIndex] = useState(-1);
   const [quizList, setQuizList] = useState<QuizList[]>([]);
   const [openModal, setOpenModal] = useState(false);
-  const navigate = useNavigate();
-
-  const handleSelectClass = (index: number) => {
-    if (selectedClassIndex === index) {
-      setSelectedClassIndex(-1);
-      return;
-    }
-    setSelectedClassIndex(index);
-  };
-
-  const handleQuizStart = async (id: number) => {
-    const socket = getQuizSocket();
-    socket.emit('master entry', { classId: id });
-    /**비동기 작업 */
-    const sid = await waitForSocketEvent('session', socket);
-    setCookie('sid', sid);
-
-    const pinCode = await waitForSocketEvent('pincode', socket);
-    setCookie('pinCode', pinCode);
-
-    navigate(`/quiz/wait/${pinCode}`);
-  };
 
   useEffect(() => {
     if (!classList) return;
@@ -63,39 +36,12 @@ export default function QuizList() {
     <div className="flex flex-col gap-10 w-full mt-6 mx-6">
       {classList ? (
         classList.map((quiz, index) => (
-          <div key={quiz.title}>
-            <div
-              className={`flex justify-between itemds-center min-w-content h-20 items-center bg-white ${selectedClassIndex === index ? 'border-secondary' : 'border-border'}  border rounded-base p-6 cursor-pointer`}
-              onClick={() => handleSelectClass(index)}
-            >
-              <span>{quiz.title}</span>
-              <div className="flex gap-12">
-                <CustomButton
-                  type="full"
-                  label="퀴즈 시작하기"
-                  color="secondary"
-                  onClick={() => handleQuizStart(quiz.id)}
-                />
-                <button type="button" onClick={() => handleSelectClass(index)}>
-                  <DownArrowIcon
-                    stroke="#000000"
-                    className={selectedClassIndex === index ? 'rotate-180' : 'rotate-0'}
-                  />
-                </button>
-              </div>
-            </div>
-            {selectedClassIndex === index && (
-              <div
-                className={`flex flex-col gap-3 p-6 mt-4 border ${selectedClassIndex === index ? 'border-secondary' : 'border-border'} rounded-base bg-white`}
-              >
-                {quizList[index].map((quizData, index) => (
-                  <span key={quizData.content}>
-                    {index + 1}번 문제: {quizData.content}
-                  </span>
-                ))}
-              </div>
-            )}
-          </div>
+          <ClassItem
+            key={`${quiz.title}+ ${index}`}
+            quiz={quiz}
+            index={index}
+            quizList={quizList}
+          />
         ))
       ) : (
         <div>왜 안되는데</div>

--- a/packages/client/src/pages/quiz-list/ui/ClassItem.tsx
+++ b/packages/client/src/pages/quiz-list/ui/ClassItem.tsx
@@ -1,0 +1,96 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { CustomButton } from '@/shared/ui/buttons';
+import { setCookie } from '@/shared/utils/cookie';
+import { getQuizSocket } from '@/shared/utils/socket';
+import { waitForSocketEvent } from '@/shared/utils/waitForSocketEvent';
+import { QuizData } from '@/pages/quiz-create';
+import DownArrowIcon from '@/shared/assets/icons/down-arrow.svg?react';
+import BinIcon from '@/shared/assets/icons/bin.svg?react';
+import { useDeleteClass } from '@/shared/hooks/classes';
+
+type QuizList = QuizData[];
+
+interface Quiz {
+  id: number;
+  title: string;
+}
+
+interface ClassItemProps {
+  quiz: Quiz;
+  index: number;
+  quizList: QuizList[];
+}
+
+export default function ClassItem({ quiz, index, quizList }: ClassItemProps) {
+  const [selectedClassIndex, setSelectedClassIndex] = useState(-1);
+
+  const mutation = useDeleteClass();
+  const navigate = useNavigate();
+
+  const handleSelectClass = (index: number) => {
+    if (selectedClassIndex === index) {
+      setSelectedClassIndex(-1);
+      return;
+    }
+    setSelectedClassIndex(index);
+  };
+
+  const handleQuizStart = async (id: number) => {
+    const socket = getQuizSocket();
+    socket.emit('master entry', { classId: id });
+    /**비동기 작업 */
+    const sid = await waitForSocketEvent('session', socket);
+    setCookie('sid', sid);
+
+    const pinCode = await waitForSocketEvent('pincode', socket);
+    setCookie('pinCode', pinCode);
+
+    navigate(`/quiz/wait/${pinCode}`);
+  };
+
+  const handleDeleteClass = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    mutation.mutate(quiz.id);
+  };
+
+  return (
+    <>
+      <div
+        className={`flex justify-between itemds-center min-w-content h-20 items-center bg-white ${selectedClassIndex === index ? 'border-secondary' : 'border-border'}  border rounded-base p-6 cursor-pointer`}
+        onClick={() => handleSelectClass(index)}
+      >
+        <span>{quiz.title}</span>
+        <div className="flex gap-4">
+          <button type="button" onClick={handleDeleteClass}>
+            <BinIcon className="w-5 h-5 text-red-500" />
+          </button>
+          <CustomButton
+            type="full"
+            label="퀴즈 시작하기"
+            color="secondary"
+            onClick={() => handleQuizStart(quiz.id)}
+          />
+          <button type="button" onClick={() => handleSelectClass(index)}>
+            <DownArrowIcon
+              stroke="#000000"
+              className={selectedClassIndex === index ? 'rotate-180' : 'rotate-0'}
+            />
+          </button>
+        </div>
+      </div>
+      {selectedClassIndex === index && (
+        <div
+          className={`flex flex-col gap-3 p-6 mt-4 border ${selectedClassIndex === index ? 'border-secondary' : 'border-border'} rounded-base bg-white`}
+        >
+          {quizList[index].map((quizData, index) => (
+            <span key={quizData.content}>
+              {index + 1}번 문제: {quizData.content}
+            </span>
+          ))}
+        </div>
+      )}
+    </>
+  );
+}

--- a/packages/client/src/pages/quiz-list/ui/QuizTitleModal.tsx
+++ b/packages/client/src/pages/quiz-list/ui/QuizTitleModal.tsx
@@ -15,12 +15,6 @@ export default function QuizTitleModal({ onClose }: QuizTitleModalProps) {
   const toast = toastController();
   const { mutate } = useCreateClass();
 
-  const handleEnterKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') {
-      handleConfirmClick();
-    }
-  };
-
   const handleConfirmClick = () => {
     if (!title || !description) {
       toast.warning('제목과 설명을 입력해주세요');
@@ -37,9 +31,13 @@ export default function QuizTitleModal({ onClose }: QuizTitleModalProps) {
     );
   };
   return (
-    <div
+    <form
       className="w-[480px] h-[250px] flex flex-col items-center justify-center gap-4 p-5 bg-white rounded-lg border border-gray-200"
       onClick={(e) => e.stopPropagation()}
+      onSubmit={(e) => {
+        e.preventDefault();
+        handleConfirmClick();
+      }}
     >
       <h1 className="text-xl font-bold">클래스 정보를 입력해주세요</h1>
       <input
@@ -48,7 +46,6 @@ export default function QuizTitleModal({ onClose }: QuizTitleModalProps) {
         className="w-full h-10 p-3 rounded-lg border border-gray-200"
         onChange={(e) => setTitle(e.target.value)}
         value={title}
-        onKeyDown={handleEnterKeyPress}
       />
       <input
         type="text"
@@ -56,14 +53,10 @@ export default function QuizTitleModal({ onClose }: QuizTitleModalProps) {
         className="w-full h-10 p-3 rounded-lg border border-gray-200"
         onChange={(e) => setDescription(e.target.value)}
         value={description}
-        onKeyDown={handleEnterKeyPress}
       />
-      <button
-        className="w-36 h-10 px-6 bg-primary text-white rounded-lg"
-        onClick={handleConfirmClick}
-      >
+      <button type="submit" className="w-36 h-10 px-6 bg-primary text-white rounded-lg">
         확인
       </button>
-    </div>
+    </form>
   );
 }

--- a/packages/client/src/pages/quiz-master-session/index.tsx
+++ b/packages/client/src/pages/quiz-master-session/index.tsx
@@ -2,7 +2,6 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { useEffect, useState } from 'react';
 
 import { getCookie } from '@/shared/utils/cookie';
-import { CustomButton } from '@/shared/ui/buttons';
 import AnswerGraph from '@/pages/quiz-master-session/ui/AnswerChart';
 import RecentSubmittedAnswers from './ui/RecentSubmittedAnswers';
 import { getQuizSocket } from '@/shared/utils/socket';
@@ -45,10 +44,11 @@ export default function QuizMasterSession() {
       navigate('/quiz/session/end');
       return;
     }
-    if (tick.remainingTime !== 0) return;
-    initQuizData();
-    setQuizIndex((prev) => prev + 1);
-    socket.emit('show quiz', { pinCode });
+    if (Math.floor(tick.remainingTime / 1000) !== 0) {
+      initQuizData();
+      setQuizIndex((prev) => prev + 1);
+      socket.emit('show quiz', { pinCode });
+    }
   };
 
   useEffect(() => {
@@ -81,7 +81,6 @@ export default function QuizMasterSession() {
       socket.off('timer tick', handleTimerTick);
     };
   }, []);
-
   return (
     <div className="w-screen min-h-screen">
       <div className="p-5">
@@ -100,7 +99,14 @@ export default function QuizMasterSession() {
                 : Math.floor(tick.remainingTime / 1000)}
             </p>
             <div className="mb-2">
-              <CustomButton label="다음 퀴즈" type="full" onClick={handleNextQuiz} />
+              <button
+                className={`bg-blue-500 text-white px-4 py-2 rounded-md disabled:bg-blue-300 disabled:cursor-not-allowed disabled:opacity-50
+  `}
+                onClick={handleNextQuiz}
+                disabled={Math.floor(tick.remainingTime / 1000) !== 0}
+              >
+                다음 퀴즈
+              </button>
             </div>
           </div>
         </div>

--- a/packages/client/src/pages/quiz-master-session/ui/EmojiChart.tsx
+++ b/packages/client/src/pages/quiz-master-session/ui/EmojiChart.tsx
@@ -7,6 +7,8 @@ interface EmojiChartProps {
   reactionStats: ReactionStats;
 }
 
+const DEFAULT_WIDTH = 30;
+
 export default function EmojiChart({ reactionStats }: EmojiChartProps) {
   const totalVotes = reactionStats.easy + reactionStats.hard;
 
@@ -41,7 +43,10 @@ export default function EmojiChart({ reactionStats }: EmojiChartProps) {
           <div
             key={index}
             className="flex flex-col items-center"
-            style={{ width: `${result.percentage}%` }}
+            style={{
+              minWidth: `${DEFAULT_WIDTH}%`,
+              flexGrow: result.percentage,
+            }}
           >
             <span className="font-medium text-lg mb-1" style={{ color: result.textColor }}>
               {result.text}
@@ -57,7 +62,8 @@ export default function EmojiChart({ reactionStats }: EmojiChartProps) {
             className="flex justify-center items-center transition-all duration-300 h-full"
             style={{
               backgroundColor: result.color,
-              width: `${result.percentage}%`,
+              minWidth: `${DEFAULT_WIDTH}%`,
+              flexGrow: result.percentage,
             }}
           >
             <span className="font-medium text-lg" style={{ color: result.textColor }}>

--- a/packages/client/src/pages/quiz-master-session/ui/StatisticsGroup.tsx
+++ b/packages/client/src/pages/quiz-master-session/ui/StatisticsGroup.tsx
@@ -30,7 +30,7 @@ export default function StatisticsGroup({ participantStatistics }: StatisticsGro
     },
     {
       title: '평균 풀이 시간',
-      value: Number(participantStatistics.averageTime.toFixed(1)),
+      value: Number((participantStatistics.averageTime / 100000).toFixed(1)),
       unit: '초',
       color: 'text-orange-500',
     },

--- a/packages/client/src/shared/api/classes/index.ts
+++ b/packages/client/src/shared/api/classes/index.ts
@@ -24,3 +24,7 @@ export async function createClass(data: CreateClassRequest): Promise<CreateClass
     body: data,
   });
 }
+
+export async function deleteClass(id: number): Promise<void> {
+  return await apiClient.delete(`/classes/${id}`);
+}

--- a/packages/client/src/shared/assets/icons/bin.svg
+++ b/packages/client/src/shared/assets/icons/bin.svg
@@ -1,0 +1,6 @@
+<svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M3.18848 6.25195H5.18848H21.1885" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M19.1885 6.25195V20.252C19.1885 20.7824 18.9778 21.2911 18.6027 21.6662C18.2276 22.0412 17.7189 22.252 17.1885 22.252H7.18848C6.65804 22.252 6.14934 22.0412 5.77426 21.6662C5.39919 21.2911 5.18848 20.7824 5.18848 20.252V6.25195M8.18848 6.25195V4.25195C8.18848 3.72152 8.39919 3.21281 8.77426 2.83774C9.14934 2.46267 9.65804 2.25195 10.1885 2.25195H14.1885C14.7189 2.25195 15.2276 2.46267 15.6027 2.83774C15.9778 3.21281 16.1885 3.72152 16.1885 4.25195V6.25195" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M10.1885 11.252V17.252" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M14.1885 11.252V17.252" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/packages/client/src/shared/hooks/classes.ts
+++ b/packages/client/src/shared/hooks/classes.ts
@@ -1,5 +1,5 @@
-import { useMutation, useQuery } from '@tanstack/react-query';
-import { createClass, getClasses } from '@/shared/api/classes';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { createClass, deleteClass, getClasses } from '@/shared/api/classes';
 import { toastController } from '@/features/toast/model/toastController';
 
 export const useGetClasses = () => {
@@ -18,5 +18,22 @@ export const useCreateClass = () => {
     mutationFn: (data: { title: string; description: string }) => createClass(data),
     onSuccess: () => toast.success('클래스가 생성되었습니다.'),
     onError: () => toast.error('클래스 생성에 실패했습니다.'),
+  });
+};
+
+export const useDeleteClass = () => {
+  const toast = toastController();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationKey: ['class', 'delete'],
+    mutationFn: (id: number) => deleteClass(id),
+    onSuccess: () => {
+      toast.success('클래스가 삭제되었습니다.');
+      return queryClient.invalidateQueries({
+        queryKey: ['classes'],
+      });
+    },
+    onError: () => toast.error('클래스 삭제에 실패했습니다.'),
   });
 };


### PR DESCRIPTION
## #️⃣연관된 이슈
[#134] - 클래스, 퀴즈 생성 페이지 에러 해결

## 📝작업 내용
- 클래스 생성 페이지에서 enter 클릭 시 2개가 생성되는 에러 해결
- 클래스 삭제 API 추가
- 퀴즈 삭제 버튼 추가
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

### 스크린샷
**퀴즈 삭제 버튼**
<img width="1704" alt="image" src="https://github.com/user-attachments/assets/f49178fa-7241-4e6c-8909-38febde8d6fc">

**클래스 삭제 버튼**
<img width="1710" alt="image" src="https://github.com/user-attachments/assets/556e24ae-009f-4b67-bb48-c8f0bb75e57b">



## 💬리뷰 요구사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->

<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
## 참고 자료
