### PR TITLE
[BE - #153] 게임 참여 인원 체크 API 구현 및 participant entry 이벤트 분리 

### DIFF
--- a/packages/server/src/module/game/games/game.controller.ts
+++ b/packages/server/src/module/game/games/game.controller.ts
@@ -16,4 +16,10 @@ export class GameController {
   async checkSidType(@Param('sid') sid: string, @Param('pinCode') pinCode: string) {
     return await this.gameService.checkSidType(sid);
   }
+
+  @Get('games/:pinCode/check')
+  @UsePipes(ValidationPipe)
+  async checkAccumulation(@Param('pinCode') pinCode: string) {
+    return await this.gameService.checkAccumulation(pinCode);
+  }
 }

--- a/packages/server/src/module/game/games/game.gateway.ts
+++ b/packages/server/src/module/game/games/game.gateway.ts
@@ -24,6 +24,7 @@ import {
   MASTER_POSITION,
   QUIZ_WAITING_TIME,
   INTERVAL_TIME,
+  PARTICIPANT_MAX_NUMBER,
 } from '@shared/constants/game.constants';
 import { CONVERT_TO_MS } from '@shared/constants/utils.constants';
 import { CONNECTION_TYPES } from '@shared/types/connection.types';
@@ -57,19 +58,12 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
     const data = JSON.parse(await this.redisService.get(key));
 
     if (data) {
-      const { pinCode, position } = data;
+      const { pinCode } = data;
       data['socketId'] = client.id;
       data['connection'] = CONNECTION_TYPES.ON;
 
       await this.redisService.set(key, JSON.stringify(data));
       client.join(pinCode);
-
-      const gameInfoJson = await this.redisService.get(`gameId=${pinCode}`);
-      if (gameInfoJson) {
-        const gameInfo = JSON.parse(gameInfoJson);
-        const myPositionData = { participantList: gameInfo.participantList, myPosition: position };
-        client.emit('my position', myPositionData);
-      }
     }
   }
 
@@ -109,37 +103,58 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
     client.emit('pincode', pinCode);
   }
 
-  @SubscribeMessage('participant entry')
-  async handleParticipantEntry(client: Socket, payload: ParticipantEntryRequestDto) {
-    const { pinCode, nickname } = payload;
+  @SubscribeMessage('session')
+  async handleSession(client: Socket, dto) {
+    const { pinCode, nickname } = dto;
     const socketId = client.id;
 
     const gameInfo = JSON.parse(await this.redisService.get(`gameId=${pinCode}`));
+    const participantLength = gameInfo.participantList.length;
 
-    // TODO: 만약 participant.length가 32로 제한이면 더이상 못들어오도록 막아야함 -> gameState를 업데이트?
+    if (participantLength >= PARTICIPANT_MAX_NUMBER) {
+      return undefined;
+    }
+
+    const participantSid = uuidv4();
     const character = Math.floor(Math.random() * 6);
-    const position = gameInfo.participantList.length;
+    const position = participantLength;
     const connection = CONNECTION_TYPES.ON;
 
     const clientInfo = { pinCode, nickname, socketId, character, position, connection };
 
     client.join(pinCode);
 
-    const participantSid = uuidv4();
     await this.redisService.set(`participant_sid=${participantSid}`, JSON.stringify(clientInfo));
-    client.emit('session', participantSid);
-
     await this.redisService.zincrby(`gameId=${pinCode}:ranking`, 0, participantSid);
 
     const pariticipantInfo = { nickname, character, position, connection };
     gameInfo.participantList.push(pariticipantInfo);
+
     await this.redisService.set(`gameId=${pinCode}`, JSON.stringify(gameInfo));
 
-    const nicknameEventData = { participantList: gameInfo.participantList };
-    const myPositionData = { participantList: gameInfo.participantList, myPosition: position };
+    return participantSid;
+  }
 
-    client.emit('my position', myPositionData);
-    client.to(pinCode).emit('nickname', nicknameEventData);
+  @SubscribeMessage('participant notice')
+  async handleParticipantNotice(client: Socket, dto) {
+    const { pinCode } = dto;
+    client.to(pinCode).emit('participant notice');
+  }
+
+  @SubscribeMessage('participant info')
+  async handleNickname(client: Socket, dto) {
+    const { pinCode, sid } = dto;
+    const gameInfo = JSON.parse(await this.redisService.get(`gameId=${pinCode}`));
+
+    const sidType = await this.gameService.checkSidType(sid);
+    const key = sidType.type === 'master' ? `master_sid=${sid}` : `participant_sid=${sid}`;
+
+    const data = JSON.parse(await this.redisService.get(key));
+
+    const myPosition = data.position;
+    const participantList = gameInfo.participantList;
+
+    return { myPosition, participantList };
   }
 
   @SubscribeMessage('show quiz')

--- a/packages/server/src/module/game/games/game.service.ts
+++ b/packages/server/src/module/game/games/game.service.ts
@@ -4,7 +4,7 @@ import { ClassRepository } from '../../quiz/quizzes/repositories/class.repositor
 import { QuizRepository } from '../../quiz/quizzes/repositories/quiz.repository';
 import { RedisService } from '../../../config/database/redis/redis.service';
 import { Quiz } from 'src/module/quiz/quizzes/entities/quiz.entity';
-// import { RANK_THREE } from '@shared/constants/game.constants';
+import { PARTICIPANT_MAX_NUMBER } from '@shared/constants/game.constants';
 
 @Injectable()
 export class GameService {
@@ -85,5 +85,13 @@ export class GameService {
       .filter((item) => item !== undefined);
 
     return formattedRank;
+  }
+
+  async checkAccumulation(pinCode: string) {
+    const gameInfo = JSON.parse(await this.redisService.get(`gameId=${pinCode}`));
+    const participantLength = gameInfo.participantList.length;
+
+    const isPossible = participantLength >= PARTICIPANT_MAX_NUMBER ? false : true;
+    return { isPossible };
   }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
#153 
<!-- ex) #이슈번호, #이슈번호 -->

## 📝작업 내용
- 게임 참여 인원 제한을 위해 참여 인원을 체크하는 API를 생성했습니다. 
    - 32명 인원 제한을 위해서 체크하는 로직을 추가했습니다.
- participant entry에서 emit하는 이벤트가 많아서, 해당 이벤트들을 분리하였습니다.
    -  session 이벤트 : sid를 생성해서 return 
    - participant Info 이벤트 : pariticipantList, myPosition
    - participant notice 이벤트 : 새로운 참여자가 들어왔다는 것을 알림

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

### 스크린샷

## 💬리뷰 요구사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->

<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
## 참고 자료
