### PR TITLE
[FE] - 퀴즈 리스트 페이지 에러 해결

### DIFF
--- a/packages/client/src/pages/quiz-create/index.tsx
+++ b/packages/client/src/pages/quiz-create/index.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { CustomButton } from '@/shared/ui/buttons';
 import PlusIcon from '@/shared/assets/icons/plus.svg?react';
 import QuizCreateSection from './ui/QuizCreateSection';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { useCreateQuiz } from '@/shared/hooks/quizzes';
 
 interface Choice {
@@ -39,7 +39,6 @@ export default function QuizCreatePage() {
   const [quizzes, setQuizzes] = useState<QuizData[]>([INITIAL_QUIZ_VALUE]);
   const [forceRender, setForceRender] = useState(1);
   const mutation = useCreateQuiz();
-  const navigate = useNavigate();
 
   const addNewQuiz = () => {
     setQuizzes((prev) => [...prev, INITIAL_QUIZ_VALUE]);
@@ -74,14 +73,7 @@ export default function QuizCreatePage() {
     const quizzesData = {
       quizzes: quizzes,
     };
-    mutation.mutate(
-      { quizData: quizzesData, classId: Number(classId) },
-      {
-        onSuccess: () => {
-          navigate('/quiz-list');
-        },
-      },
-    );
+    mutation.mutate({ quizData: quizzesData, classId: Number(classId) });
   };
 
   return (

--- a/packages/client/src/pages/quiz-list/index.lazy.tsx
+++ b/packages/client/src/pages/quiz-list/index.lazy.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import QuizTitleModal from './ui/QuizTitleModal';
 import { useGetClasses } from '@/shared/hooks/classes';
 import ClassItem from './ui/ClassItem';
+import EmptyQuizList from './ui/EmptyClassList';
 
 export default function QuizListLazyPage() {
   const { data: classList } = useGetClasses();
@@ -14,6 +15,7 @@ export default function QuizListLazyPage() {
       {classList.data.map((item, index) => {
         return <ClassItem key={item.id} quizList={item} index={index} />;
       })}
+      {classList.data.length === 0 && <EmptyQuizList />}
       <div className="self-end ">
         <CustomButton
           type="outline"

--- a/packages/client/src/pages/quiz-list/index.lazy.tsx
+++ b/packages/client/src/pages/quiz-list/index.lazy.tsx
@@ -1,14 +1,18 @@
 import { CustomButton } from '@/shared/ui/buttons';
 import Modal from '@/shared/ui/modal';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import QuizTitleModal from './ui/QuizTitleModal';
 import { useGetClasses } from '@/shared/hooks/classes';
 import ClassItem from './ui/ClassItem';
 import EmptyQuizList from './ui/EmptyClassList';
 
 export default function QuizListLazyPage() {
-  const { data: classList } = useGetClasses();
+  const { data: classList, refetch } = useGetClasses();
   const [openModal, setOpenModal] = useState(false);
+
+  useEffect(() => {
+    refetch();
+  }, []);
 
   return (
     <div className="w-full min-h-[calc(100vh-80px)] px-8 flex flex-col gap-6 mt-6 mx-auto">

--- a/packages/client/src/pages/quiz-list/ui/ClassItem.tsx
+++ b/packages/client/src/pages/quiz-list/ui/ClassItem.tsx
@@ -32,7 +32,8 @@ export default function ClassItem({ index, quizList }: ClassItemProps) {
     setSelectedClassIndex((prevIndex) => (prevIndex === index ? -1 : index));
   };
 
-  const handleQuizStart = async (id: number) => {
+  const handleQuizStart = async (id: number, e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
     const socket = getQuizSocket();
     socket.emit('master entry', { classId: id });
 
@@ -71,7 +72,7 @@ export default function ClassItem({ index, quizList }: ClassItemProps) {
             type="full"
             label="퀴즈 시작하기"
             color="secondary"
-            onClick={() => handleQuizStart(quizList.id)}
+            onClick={(e) => handleQuizStart(quizList.id, e)}
           />
           <button type="button" onClick={(e) => handleSelectClass(index, e)}>
             <DownArrowIcon

--- a/packages/client/src/pages/quiz-list/ui/EmptyClassList.tsx
+++ b/packages/client/src/pages/quiz-list/ui/EmptyClassList.tsx
@@ -1,0 +1,13 @@
+import { FileQuestion } from 'lucide-react';
+
+export default function EmptyQuizList() {
+  return (
+    <div className="flex flex-col items-center justify-center py-20 px-4">
+      <div className="w-24 h-24 bg-gradient-to-br from-blue-50 to-blue-100 rounded-full flex items-center justify-center mb-6 shadow-inner">
+        <FileQuestion className="w-12 h-12 text-blue-500" />
+      </div>
+      <h3 className="text-xl font-semibold text-gray-900 mb-2">퀴즈가 없습니다</h3>
+      <p className="text-gray-500 text-center mb-6">첫 퀴즈를 만들어보세요.</p>
+    </div>
+  );
+}

--- a/packages/client/src/shared/hooks/classes.ts
+++ b/packages/client/src/shared/hooks/classes.ts
@@ -3,11 +3,11 @@ import { createClass, deleteClass, getClasses } from '@/shared/api/classes';
 import { toastController } from '@/features/toast/model/toastController';
 
 export const useGetClasses = () => {
-  const { data } = useSuspenseQuery({
+  const { data, refetch } = useSuspenseQuery({
     queryKey: ['classes'],
     queryFn: () => getClasses(),
   });
-  return { data };
+  return { data, refetch };
 };
 
 export const useCreateClass = () => {

--- a/packages/client/src/shared/hooks/quizzes.ts
+++ b/packages/client/src/shared/hooks/quizzes.ts
@@ -2,6 +2,7 @@ import { useMutation } from '@tanstack/react-query';
 import { createQuiz } from '../api/quizzes';
 import { QuizData } from '@/pages/quiz-create';
 import { toastController } from '@/features/toast/model/toastController';
+import { useNavigate } from 'react-router-dom';
 
 interface Quizzes {
   quizzes: QuizData[];
@@ -14,10 +15,14 @@ interface CreateQuizParams {
 
 export const useCreateQuiz = () => {
   const toast = toastController();
+  const navigate = useNavigate();
   return useMutation({
     mutationKey: ['quiz'],
     mutationFn: ({ quizData, classId }: CreateQuizParams) => createQuiz(quizData, classId),
-    onSuccess: () => toast.success('퀴즈가 생성되었습니다.'),
+    onSuccess: () => {
+      navigate('/quiz-list');
+      toast.success('퀴즈가 생성되었습니다.');
+    },
     onError: () => toast.error('퀴즈 생성에 실패했습니다.'),
   });
 };

--- a/packages/client/src/shared/ui/buttons/CustomButton.tsx
+++ b/packages/client/src/shared/ui/buttons/CustomButton.tsx
@@ -12,7 +12,7 @@ interface CustomButtonProps {
   /** 버튼 라벨 */
   label: string;
   /** 버튼 클릭 이벤트 */
-  onClick?: () => void;
+  onClick?: React.MouseEventHandler<HTMLButtonElement>;
 }
 
 const buttonStyles = {


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- ex) #이슈번호, #이슈번호 -->

## 📝작업 내용
- 퀴즈 생성 후 퀴즈 리스트에서 생성된 클래스가 보이도록 수정
- 클래스 리스트가 비어있을 때 UI 추가
- 게임 시작하기 버튼 클릭 시 버블링 방지
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

### 스크린샷
<img width="1702" alt="image" src="https://github.com/user-attachments/assets/e44655ac-fb8b-47ae-9fd9-6fb5004b1708">

## 💬리뷰 요구사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->

<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
## 참고 자료
