### PR TITLE
[BE -#162 ] 클래스 삭제 API: 벌크 삭제로 변경

### DIFF
--- a/packages/server/src/module/quiz/quizzes/entities/choice.entity.ts
+++ b/packages/server/src/module/quiz/quizzes/entities/choice.entity.ts
@@ -1,7 +1,7 @@
 import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
 import { Quiz } from './quiz.entity';
 
-@Entity()
+@Entity('choice')
 export class Choice {
   @PrimaryGeneratedColumn()
   id: number;
@@ -18,10 +18,10 @@ export class Choice {
   @Column()
   position: number;
 
-  @Column({ name: 'created_at' }) 
+  @Column({ name: 'created_at' })
   createdAt: Date;
 
-  @ManyToOne(() => Quiz, quiz => quiz.choices)
-  @JoinColumn({ name: 'quiz_id' })
+  @ManyToOne(() => Quiz, (quiz) => quiz.choices)
+  @JoinColumn({ name: 'quiz_id', referencedColumnName: 'id' })
   quiz: Quiz;
 }

--- a/packages/server/src/module/quiz/quizzes/quiz.service.ts
+++ b/packages/server/src/module/quiz/quizzes/quiz.service.ts
@@ -103,12 +103,6 @@ export class QuizService {
   }
 
   async deleteClass(id: number): Promise<void> {
-    const classEntity = await this.classRepository.findClassWithRelations(id);
-
-    if (!classEntity) {
-      throw new NotFoundException(`Class with ID ${id} not found`);
-    }
-
-    await this.classRepository.deleteWithRelations(classEntity);
+    await this.classRepository.deleteWithRelations(id);
   }
 }

--- a/packages/server/src/module/quiz/quizzes/repositories/class.repository.ts
+++ b/packages/server/src/module/quiz/quizzes/repositories/class.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable, InternalServerErrorException, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { DataSource, Repository } from 'typeorm';
 import { Class } from '../entities/class.entity';
 import { Quiz } from '../entities/quiz.entity';
 import { Choice } from '../entities/choice.entity';
@@ -10,6 +10,7 @@ export class ClassRepository {
   constructor(
     @InjectRepository(Class)
     private readonly repository: Repository<Class>,
+    private readonly dataSource: DataSource,
   ) {}
 
   async create(classData: Partial<Class>): Promise<Class> {
@@ -129,40 +130,25 @@ export class ClassRepository {
     }
   }
 
-  async deleteWithRelations(classEntity: Class): Promise<void> {
-    const queryRunner = this.repository.manager.connection.createQueryRunner();
+  async deleteWithRelations(id: number): Promise<void> {
+    const queryRunner = this.dataSource.createQueryRunner();
     await queryRunner.connect();
     await queryRunner.startTransaction();
 
     try {
-      // 1. 먼저 모든 하위 Choice 삭제
-      if (classEntity.quizzes) {
-        for (const quiz of classEntity.quizzes) {
-          if (quiz.choices && quiz.choices.length > 0) {
-            await queryRunner.manager.delete(Choice, {
-              quizId: quiz.id,
-            });
-          }
-        }
-      }
+      await queryRunner.query(
+        `DELETE FROM choice WHERE quiz_id IN (SELECT id FROM quiz WHERE class_id = ?)`,
+        [id],
+      );
 
-      // 2. Quiz 삭제
-      if (classEntity.quizzes && classEntity.quizzes.length > 0) {
-        await queryRunner.manager.delete(Quiz, {
-          classId: classEntity.id,
-        });
-      }
+      await queryRunner.query(`DELETE FROM quiz WHERE class_id = ?`, [id]);
 
-      // 3. 마지막으로 Class 삭제
-      await queryRunner.manager.delete(Class, {
-        id: classEntity.id,
-      });
+      await queryRunner.query(`DELETE FROM class WHERE id = ?`, [id]);
 
       await queryRunner.commitTransaction();
     } catch (error) {
-      console.error('Failed to delete class with relations:', error);
       await queryRunner.rollbackTransaction();
-      throw error;
+      throw new InternalServerErrorException('Failed to delete');
     } finally {
       await queryRunner.release();
     }


### PR DESCRIPTION
## #️⃣연관된 이슈
#162 벌크 삭제로 쿼리 개선

## 📝작업 내용
벌크 삭제로 쿼리 개선
```
  async deleteWithRelations(id: number): Promise<void> {
    const queryRunner = this.dataSource.createQueryRunner();
    await queryRunner.connect();
    await queryRunner.startTransaction();

    try {
      await queryRunner.query(
        `DELETE FROM choice WHERE quiz_id IN (SELECT id FROM quiz WHERE class_id = ?)`,
        [id],
      );

      await queryRunner.query(`DELETE FROM quiz WHERE class_id = ?`, [id]);

      await queryRunner.query(`DELETE FROM class WHERE id = ?`, [id]);

      await queryRunner.commitTransaction();
    } catch (error) {
      await queryRunner.rollbackTransaction();
      throw new InternalServerErrorException('Failed to delete');
    } finally {
      await queryRunner.release();
    }
  }
```

### 스크린샷
성능 개선 지표는 기술적 공유에 업로드 완료
## 💬리뷰 요구사항

## 참고 자료
https://cookie-lentil-cdb.notion.site/8914f3d4d34c469e9a1b55d8fb12b860