### PR TITLE
[BE -#168] 벌크 삭제 로직 책임 분리

### DIFF
--- a/packages/server/src/module/quiz/quizzes/entities/quiz.entity.ts
+++ b/packages/server/src/module/quiz/quizzes/entities/quiz.entity.ts
@@ -3,7 +3,7 @@ import { QuizType } from '../utils/quiz-type.enum';
 import { Choice } from './choice.entity';
 import { Class } from './class.entity';
 
-@Entity()
+@Entity('quiz')
 export class Quiz {
   @PrimaryGeneratedColumn()
   id: number;
@@ -15,10 +15,10 @@ export class Quiz {
   content: string;
 
   @Column({
-      name: 'quiz_type',
-      type: 'enum',
-      enum: QuizType,
-      default: QuizType.TF,
+    name: 'quiz_type',
+    type: 'enum',
+    enum: QuizType,
+    default: QuizType.TF,
   })
   quizType: QuizType;
 
@@ -29,18 +29,18 @@ export class Quiz {
   point: number;
 
   @Column()
-  position: number
+  position: number;
 
   @Column({ name: 'created_at' })
   createdAt: Date;
 
-  @OneToMany(() => Choice, choice => choice.quiz, {
+  @OneToMany(() => Choice, (choice) => choice.quiz, {
     cascade: true,
-    eager: false
+    eager: false,
   })
   choices: Choice[];
 
-  @ManyToOne(() => Class, cls => cls.quizzes)
-  @JoinColumn({ name: 'class_id' })
+  @ManyToOne(() => Class, (cls) => cls.quizzes)
+  @JoinColumn([{ name: 'class_id', referencedColumnName: 'id' }])
   class: Class;
 }

--- a/packages/server/src/module/quiz/quizzes/quiz.service.ts
+++ b/packages/server/src/module/quiz/quizzes/quiz.service.ts
@@ -106,6 +106,11 @@ export class QuizService {
   }
 
   async deleteClass(id: number): Promise<void> {
-    await this.classRepository.deleteWithRelations(id);
+    return this.dataSource.transaction(async (manager) => {
+      await this.classRepository.findClassById(id);
+      await this.choiceRepository.deleteByClassId(id, manager);
+      await this.quizRepository.deleteByClassId(id, manager);
+      await this.classRepository.delete(id, manager);
+    });
   }
 }

--- a/packages/server/src/module/quiz/quizzes/repositories/choice.repository.ts
+++ b/packages/server/src/module/quiz/quizzes/repositories/choice.repository.ts
@@ -11,11 +11,7 @@ export class ChoiceRepository {
     private readonly repository: Repository<Choice>,
   ) {}
 
-  async create(
-    quizId: number,
-    choiceData: CreateChoiceRequestDto,
-    manager?: EntityManager,
-  ): Promise<Choice> {
+  async create(quizId: number, choiceData: CreateChoiceRequestDto): Promise<Choice> {
     const { content, isCorrect, position } = choiceData;
     const choiceEntity = this.repository.create({
       quizId,
@@ -72,12 +68,10 @@ export class ChoiceRepository {
     }
   }
 
-  async deleteByQuizId(quizId: number, manager?: EntityManager): Promise<void> {
-    const repo = manager ? manager.getRepository(Choice) : this.repository;
-    try {
-      await repo.delete({ quizId });
-    } catch (error) {
-      throw new InternalServerErrorException('Failed to delete choices');
-    }
+  async deleteByClassId(classId: number, manager: EntityManager): Promise<void> {
+    await manager.query(
+      'DELETE FROM choice WHERE quiz_id IN (SELECT id FROM quiz WHERE class_id = ?)',
+      [classId],
+    );
   }
 }

--- a/packages/server/src/module/quiz/quizzes/repositories/class.repository.ts
+++ b/packages/server/src/module/quiz/quizzes/repositories/class.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable, InternalServerErrorException, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { DataSource, Repository } from 'typeorm';
+import { DataSource, EntityManager, Repository } from 'typeorm';
 import { Class } from '../entities/class.entity';
 
 @Injectable()
@@ -128,27 +128,7 @@ export class ClassRepository {
     }
   }
 
-  async deleteWithRelations(id: number): Promise<void> {
-    const queryRunner = this.dataSource.createQueryRunner();
-    await queryRunner.connect();
-    await queryRunner.startTransaction();
-
-    try {
-      await queryRunner.query(
-        `DELETE FROM choice WHERE quiz_id IN (SELECT id FROM quiz WHERE class_id = ?)`,
-        [id],
-      );
-
-      await queryRunner.query(`DELETE FROM quiz WHERE class_id = ?`, [id]);
-
-      await queryRunner.query(`DELETE FROM class WHERE id = ?`, [id]);
-
-      await queryRunner.commitTransaction();
-    } catch (error) {
-      await queryRunner.rollbackTransaction();
-      throw new InternalServerErrorException('Failed to delete');
-    } finally {
-      await queryRunner.release();
-    }
+  async delete(id: number, manager: EntityManager): Promise<void> {
+    await manager.delete(Class, { id });
   }
 }

--- a/packages/server/src/module/quiz/quizzes/repositories/quiz.repository.ts
+++ b/packages/server/src/module/quiz/quizzes/repositories/quiz.repository.ts
@@ -198,4 +198,8 @@ export class QuizRepository {
       await queryRunner.release();
     }
   }
+
+  async deleteByClassId(classId: number, manager: EntityManager): Promise<void> {
+    await manager.query('DELETE FROM quiz WHERE class_id = ?', [classId]);
+  }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
#168 벌크 삭제 로직 분리

## 📝작업 내용
기존 코드는 아래와 같다.  이 코드는 class repository에 존재하는 메서드였으나, 엔티티 별 책임분리가 안되어있는 모습이 보였다.
```tsx
  async deleteWithRelations(id: number): Promise<void> {
    const queryRunner = this.dataSource.createQueryRunner();
    await queryRunner.connect();
    await queryRunner.startTransaction();

    try {
      await queryRunner.query(
        `DELETE FROM choice WHERE quiz_id IN (SELECT id FROM quiz WHERE class_id = ?)`,
        [id],
      );

      await queryRunner.query(`DELETE FROM quiz WHERE class_id = ?`, [id]);

      await queryRunner.query(`DELETE FROM class WHERE id = ?`, [id]);

      await queryRunner.commitTransaction();
    } catch (error) {
      await queryRunner.rollbackTransaction();
      throw new InternalServerErrorException('Failed to delete');
    } finally {
      await queryRunner.release();
    }
  }
```

일단 역할 분리부터 진행했다. SRP원칙에 의해 서비스 레이어에서는 DB에 직접 접근하지않되, 레포지토리 레벨에 접근을 위임하기로 했다.

현재 Class를 삭제하면 연관된 Quiz, Choice를 삭제해야하기에 3개의 테이블에 접근하는 트랜잭션이 수행된다.

그렇기에 서비스 레이어에서 트랜잭션을 시작하고, 각 테이블에서 순차적으로 벌크 삭제를 진행한다.

```tsx
// quiz.service.ts
async deleteClass(id: number): Promise<void> {
  return this.dataSource.transaction(async (manager) => {
    await this.classRepository.findClassById(id);
    await this.choiceRepository.deleteByClassId(id, manager);
    await this.quizRepository.deleteByClassId(id, manager);
    await this.classRepository.delete(id, manager);
  });
}

// class.respository.ts
async delete(id: number, manager: EntityManager): Promise<void> {
  await manager.delete(Class, { id });
}

async findById(id: number): Promise<Class> {
  try {
    const result = await this.repository.findOne({ where: { id } });
    if (!result) {
      throw new NotFoundException(`Class with ID ${id} not found`);
    }
    return result;
  } catch (error) {
    if (error instanceof NotFoundException) throw error;
    throw new InternalServerErrorException('Failed to fetch class');
  }
}

// quiz.respository.ts
async deleteByClassId(classId: number, manager: EntityManager): Promise<void> {
  await manager.query('DELETE FROM quiz WHERE class_id = ?', [classId]);
}

// choice.repository.ts
async deleteByClassId(classId: number, manager: EntityManager): Promise<void> {
  await manager.query(
    'DELETE FROM choice WHERE quiz_id IN (SELECT id FROM quiz WHERE class_id = ?)',
    [classId],
  );
}
```

역할을 다음과 같이 분리했고, TypeORM의 transaction()에서 자동으로 에러 처리, rollback, commit을 하기에 추가적인 구현은 진행하지않았다.

### 스크린샷

## 💬리뷰 요구사항
테스트 완료

## 참고 자료
